### PR TITLE
breaking change: remove dependency to Moment.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is basically Javascript implementation of [Moshier's ephemeris](http://www.
 Which, initially written by [mivion](https://github.com/mivion/ephemeris), xerik converted it into a node module. This is a slight customized version with following changes:
 
 1. Changes the transit method to get standard sun/moon rise/set times as well as a custom horizon based
-1. Takes in Moment date object as opposed to a date time string
+1. Takes in javascript date object as opposed to a date time string
 1. Implements a method to just fetch in single planet as opposed to all of it
 1. Removes html, css bit to keep it focused to one task
 1. Reformats the code
@@ -19,8 +19,7 @@ Which, initially written by [mivion](https://github.com/mivion/ephemeris), xerik
 *app.js*
 ```javascript
 const ephemeris = require('ephemeris');
-const Moment = require('moment-timezone');
-const dateObj = new Moment.tz('10.08.2015 17:09:01', 'DD.MM.YYYY HH:mm:ss', 'UTC')
+const dateObj = new Date('2015-08-10T17:09:01.000+08:00');
 
 // parameters: ephemeris.getAllPlanets(dateObj, longitude, latitude, height);
 var result = ephemeris.getAllPlanets(dateObj, 10.0014, 53.5653, 0);

--- a/index.js
+++ b/index.js
@@ -2,38 +2,26 @@
 
 var eph = require('./build/')
 
-function setUp (iDate, geodeticalLongitude, geodeticalLatitude, height) {
-  var date
-
+function setUp (date, geodeticalLongitude, geodeticalLatitude, height) {
+  var d = !date ? new Date() : date;
   eph.const.tlong = geodeticalLongitude
   eph.const.glat = geodeticalLatitude
   eph.const.height = height
-
-  eph.const.date = iDate.format('DD.MM.YYYY HH:mm:ss')
-
-  if (eph.const.date) {
-    var tokens = eph.const.date.split(' ')
-
-    tokens[0] = tokens[0].split('.')
-    tokens[1] = tokens[1].split(':')
-
-    date = {
-      day: parseFloat(tokens[0][0]), // parseFloat strips leading zeros
-      month: parseFloat(tokens[0][1]),
-      year: parseFloat(tokens[0][2]),
-      hours: parseFloat(tokens[1][0]),
-      minutes: parseFloat(tokens[1][1]),
-      seconds: parseFloat(tokens[1][2])
-    }
-    eph.const.date = date
+  eph.const.date = {
+    day: d.getUTCDate(),
+    month: d.getUTCMonth()+1,
+    year: d.getUTCFullYear(),
+    hours: d.getUTCHours(),
+    minutes: d.getUTCMinutes(),
+    seconds: d.getUTCSeconds()
   }
   eph.processor.init()
 }
 
-// Example call: getAllPlanets(momentDateObj, 10.0014, 53.5653, 0);
-function getAllPlanets (iDate, geodeticalLongitude, geodeticalLatitude, height) {
+// Example call: getAllPlanets(new Date(), 10.0014, 53.5653, 0);
+function getAllPlanets (date, geodeticalLongitude, geodeticalLatitude, height) {
 
-  setUp(iDate, geodeticalLongitude, geodeticalLatitude, height)
+  setUp(date, geodeticalLongitude, geodeticalLatitude, height)
 
   var ret = {
     date: undefined,
@@ -93,10 +81,10 @@ function getAllPlanets (iDate, geodeticalLongitude, geodeticalLatitude, height) 
   return ret
 }
 
-// Example call: getPlanet('moon', momentDateObj, 10.0014, 53.5653, 0);
-function getPlanet (planetName, iDate, geodeticalLongitude, geodeticalLatitude, height) {
+// Example call: getPlanet('moon', new Date(), 10.0014, 53.5653, 0);
+function getPlanet (planetName, date, geodeticalLongitude, geodeticalLatitude, height) {
 
-  setUp(iDate, geodeticalLongitude, geodeticalLatitude, height)
+  setUp(date, geodeticalLongitude, geodeticalLatitude, height)
 
   var ret = {
     date: undefined,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "Hemantkumar Goswami",
   "license": "GPL-3.0",
   "devDependencies": {
-    "moment-timezone": "^0.5.31",
     "path": "^0.12.7",
     "tape": "^4.13.3"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,14 +1,12 @@
 // This file is a placeholder and needs more tests.
 
 var test = require('tape');
-var Moment = require('moment-timezone');
 
 var ephemeris = require('../');
 
 test('dummy test', function (t) {
     t.plan(3);
-    var dateObj = new Moment.tz('10.08.2015 17:09:01', 'DD.MM.YYYY HH:mm:ss', 'UTC')
-
+    var dateObj = new Date('2015-08-10T17:09:01.000+00:00');
     var result = ephemeris.getAllPlanets(dateObj, 10.0014, 53.5653, 0);
 
     t.equal(result.date.gregorianTerrestrial, '10.8.2015 17:9:1');


### PR DESCRIPTION
I suggest removing the dependency to the third-party library Moment.js because the built-in JavaScript Date object can easily do the trick. Looking ahead, third-party libraries such as Moment.js are only prone to become more obsolete and add a dependency burden, also Moment.js already has a successor called "luxon". Some history: Moment.js came into existence when plain JavaScript date manipulation was very limited. Later JavaScript added features such as "Intl.DateTimeFormat" which largely do away with the need for third-party tools for date manipulation.