### PR TITLE
DON'T MERGE - support for type inference

### DIFF
--- a/src/astronomy/moshier/aberration.js
+++ b/src/astronomy/moshier/aberration.js
@@ -1,16 +1,15 @@
 $ns.aberration = {}
 
-$ns.aberration.calc = function (p, result) {
+$ns.aberration.calc = function (p) {
   var x = [], V = [] // double
 
   /* Calculate the velocity of the earth (see vearth.js). */
   $moshier.vearth.calc($moshier.body.earth.position.date)
   var betai = 0.0, pV = 0.0
   for (var i = 0; i < 3; i++) {
-    var A = $moshier.vearth.vearth[i] / $const.Clightaud
-    V[i] = A
-    betai += A * A
-    pV += p[i] * A
+    V[i] = $moshier.vearth.vearth[i] / $const.Clightaud
+    betai += V[i] * V[i]
+    pV += p[i] * V[i]
   }
   /* Make the adjustment for aberration. */
   betai = Math.sqrt(1 - betai)
@@ -19,14 +18,11 @@ $ns.aberration.calc = function (p, result) {
   var B = (1 + pV / (1 + betai)) / C
 
   for (var i = 0; i < 3; i++) {
-    C = A * p[i] + B * V[i]
-    x[i] = C
-    $const.dp[i] = C - p[i]
+    x[i] = A * p[i] + B * V[i]
+    $const.dp[i] = x[i] - p[i]
   }
 
-  result = result || {}
-
-  $util.showcor(p, $const.dp, result)
+  var result = $util.showcor(p, $const.dp)
   for (var i = 0; i < 3; i++) {
     p[i] = x[i]
   }

--- a/src/astronomy/moshier/aberration.js
+++ b/src/astronomy/moshier/aberration.js
@@ -1,29 +1,24 @@
 $ns.aberration = {}
 
 $ns.aberration.calc = function (p, result) {
-  var A, B, C // double
-  var betai, pV // double
   var x = [], V = [] // double
-  var i // int
 
-  /* Calculate the velocity of the earth (see vearth.js).
-   */
+  /* Calculate the velocity of the earth (see vearth.js). */
   $moshier.vearth.calc($moshier.body.earth.position.date)
-  betai = 0.0
-  pV = 0.0
-  for (i = 0; i < 3; i++) {
-    A = $moshier.vearth.vearth [i] / $const.Clightaud
+  var betai = 0.0, pV = 0.0
+  for (var i = 0; i < 3; i++) {
+    var A = $moshier.vearth.vearth[i] / $const.Clightaud
     V[i] = A
     betai += A * A
     pV += p[i] * A
   }
   /* Make the adjustment for aberration. */
   betai = Math.sqrt(1.0 - betai)
-  C = 1.0 + pV
-  A = betai / C
-  B = (1.0 + pV / (1.0 + betai)) / C
+  var C = 1.0 + pV
+  var A = betai / C
+  var B = (1.0 + pV / (1.0 + betai)) / C
 
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     C = A * p[i] + B * V[i]
     x[i] = C
     $const.dp[i] = C - p[i]
@@ -32,7 +27,7 @@ $ns.aberration.calc = function (p, result) {
   result = result || {}
 
   $util.showcor(p, $const.dp, result)
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     p[i] = x[i]
   }
 

--- a/src/astronomy/moshier/aberration.js
+++ b/src/astronomy/moshier/aberration.js
@@ -13,10 +13,10 @@ $ns.aberration.calc = function (p, result) {
     pV += p[i] * A
   }
   /* Make the adjustment for aberration. */
-  betai = Math.sqrt(1.0 - betai)
-  var C = 1.0 + pV
+  betai = Math.sqrt(1 - betai)
+  var C = 1 + pV
   var A = betai / C
-  var B = (1.0 + pV / (1.0 + betai)) / C
+  var B = (1 + pV / (1 + betai)) / C
 
   for (var i = 0; i < 3; i++) {
     C = A * p[i] + B * V[i]

--- a/src/astronomy/moshier/altaz.js
+++ b/src/astronomy/moshier/altaz.js
@@ -10,10 +10,10 @@ $ns.altaz.calc = function (pol, date, result) {
   var ra = pol[0]
   var dec = pol[1]
   var dist = pol[2]
-  // var TPI = 2.0 * Math.PI
+  // var TPI = 2 * Math.PI
 
   /* local apparent sidereal time, seconds converted to radians */
-  var last = $moshier.sidereal.calc(date, $const.tlong) * $const.DTR / 240.0
+  var last = $moshier.sidereal.calc(date, $const.tlong) * $const.DTR / 240
   var lha = last - ra
   /* local hour angle, radians */
   result.dLocalApparentSiderealTime = last
@@ -101,7 +101,7 @@ $ns.altaz.calc = function (pol, date, result) {
   while (y > Math.PI) {
     y -= $const.TPI
   }
-  y = $const.RTS * y / 15.0
+  y = $const.RTS * y / 15
   z = $const.RTS * (dec - z)
 
   result.atmosphericRefraction = {

--- a/src/astronomy/moshier/altaz.js
+++ b/src/astronomy/moshier/altaz.js
@@ -5,20 +5,16 @@ $ns.altaz = {
 }
 
 $ns.altaz.calc = function (pol, date, result) {
-  var dec, cosdec, sindec, lha, coslha, sinlha // double
-  var ra, dist, last, alt, az, coslat, sinlat // double
-  var N, D, x, y, z, TPI // double
-
   result = result || {}
 
-  ra = pol[0]
-  dec = pol[1]
-  dist = pol[2]
-  TPI = 2.0 * Math.PI
+  var ra = pol[0]
+  var dec = pol[1]
+  var dist = pol[2]
+  // var TPI = 2.0 * Math.PI
 
   /* local apparent sidereal time, seconds converted to radians */
-  last = $moshier.sidereal.calc(date, $const.tlong) * $const.DTR / 240.0
-  lha = last - ra
+  var last = $moshier.sidereal.calc(date, $const.tlong) * $const.DTR / 240.0
+  var lha = last - ra
   /* local hour angle, radians */
   result.dLocalApparentSiderealTime = last
   result.localApparentSiderealTime = $util.hms(last)
@@ -54,21 +50,21 @@ $ns.altaz.calc = function (pol, date, result) {
   /* diurab( last, &ra, &dec ); */
 
   /* Convert ra and dec to altitude and azimuth */
-  cosdec = Math.cos(dec)
-  sindec = Math.sin(dec)
+  var cosdec = Math.cos(dec)
+  var sindec = Math.sin(dec)
   lha = last - ra
-  coslha = Math.cos(lha)
-  sinlha = Math.sin(lha)
+  var coslha = Math.cos(lha)
+  var sinlha = Math.sin(lha)
 
   /* Use the geodetic latitude for altitude and azimuth */
   x = $const.DTR * $const.glat
-  coslat = Math.cos(x)
-  sinlat = Math.sin(x)
+  var coslat = Math.cos(x)
+  var sinlat = Math.sin(x)
 
-  N = -cosdec * sinlha
-  D = sindec * coslat - cosdec * coslha * sinlat
-  az = $const.RTD * $util.zatan2(D, N)
-  alt = sindec * sinlat + cosdec * coslha * coslat
+  var N = -cosdec * sinlha
+  var D = sindec * coslat - cosdec * coslha * sinlat
+  var az = $const.RTD * $util.zatan2(D, N)
+  var alt = sindec * sinlat + cosdec * coslha * coslat
   alt = $const.RTD * Math.asin(alt)
 
   /* Store results */
@@ -84,9 +80,9 @@ $ns.altaz.calc = function (pol, date, result) {
   this.refracted_elevation = alt
 
   /* Convert back to R.A. and Dec. */
-  y = Math.sin($const.DTR * alt)
-  x = Math.cos($const.DTR * alt)
-  z = Math.cos($const.DTR * az)
+  var x = Math.cos($const.DTR * alt)
+  var y = Math.sin($const.DTR * alt)
+  var z = Math.cos($const.DTR * az)
   sinlha = -x * Math.sin($const.DTR * az)
   coslha = y * coslat - x * z * sinlat
   sindec = y * sinlat + x * z * coslat

--- a/src/astronomy/moshier/altaz.js
+++ b/src/astronomy/moshier/altaz.js
@@ -4,9 +4,7 @@ $ns.altaz = {
   refracted_elevation: 0.0
 }
 
-$ns.altaz.calc = function (pol, date, result) {
-  result = result || {}
-
+$ns.altaz.calc = function (pol, date) {
   var ra = pol[0]
   var dec = pol[1]
   var dist = pol[2]
@@ -14,10 +12,13 @@ $ns.altaz.calc = function (pol, date, result) {
 
   /* local apparent sidereal time, seconds converted to radians */
   var last = $moshier.sidereal.calc(date, $const.tlong) * $const.DTR / 240
-  var lha = last - ra
   /* local hour angle, radians */
-  result.dLocalApparentSiderealTime = last
-  result.localApparentSiderealTime = $util.hms(last)
+  var lha = last - ra
+
+  var result = {
+    dLocalApparentSiderealTime: last,
+    localApparentSiderealTime: $util.hms(last)
+  }
 
   /* Display rate at which ra and dec are changing */
   /*

--- a/src/astronomy/moshier/constant.js
+++ b/src/astronomy/moshier/constant.js
@@ -5,7 +5,7 @@ $ns.constant = {
   j2000: 2451545.0, /* 2000 January 1.5 */
   b1950: 2433282.423, /* 1950 January 0.923 Besselian epoch */
   j1900: 2415020.0, /* 1900 January 0, 12h UT */
-  RTOH: 12.0 / Math.PI, /* Radians to hours, minutes, seconds */
+  RTOH: 12 / Math.PI, /* Radians to hours, minutes, seconds */
 
   /* Conversion factors between degrees and radians */
   DTR: 1.7453292519943295769e-2,
@@ -13,7 +13,7 @@ $ns.constant = {
   RTS: 2.0626480624709635516e5, /* arc seconds per radian */
   STR: 4.8481368110953599359e-6, /* radians per arc second */
 
-  TPI: 2.0 * Math.PI,
+  TPI: 2 * Math.PI,
 
   date: {}, /* Input date */
 

--- a/src/astronomy/moshier/constellation.js
+++ b/src/astronomy/moshier/constellation.js
@@ -1,6 +1,5 @@
 $ns.constellation = {
-  /* Constellation names
-   */
+  /* Constellation names */
   constel: [
     'And Andromedae',
     'Ant Antliae',
@@ -93,8 +92,7 @@ $ns.constellation = {
     'Vul Vulpeculae'
   ],
 
-  /* Greek letters
-   */
+  /* Greek letters */
   greek: [
     'alpha',
     'beta',
@@ -131,7 +129,7 @@ $ns.constellation = {
    Lower Right Ascension, Upper Right Ascension,
    both in units of hours times 3600;
    Lower Declination, in units of degrees times 3600;
-   and array index of constellation name.  */
+   and array index of constellation name. */
   bndries: [
     0, 86400, 316800, 84,
     28800, 52200, 311400, 84,
@@ -495,37 +493,34 @@ $ns.constellation = {
 
 /* Return the constellation name corresponding to a given mean equatorial
  position P.  EPOCH is the precessional equinox and ecliptic date
- of P.  */
+ of P. */
 $ns.constellation.calc = function (pp, epoch) {
-  var i, k // int
-  var ra, dec, d // double
   var p = [] // double
-
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     p[i] = pp[i]
   }
 
-  /* Precess from given epoch to J2000.  */
+  /* Precess from given epoch to J2000. */
   $moshier.precess.calc(p, epoch, 1)
-  /* Precess from J2000 to Besselian epoch 1875.0.  */
+  /* Precess from J2000 to Besselian epoch 1875.0. */
   $moshier.precess.calc(p, {julian: 2405889.25855}, -1)
-  d = p[0] * p[0] + p[1] * p[1] + p[2] * p[2]
+  var d = p[0] * p[0] + p[1] * p[1] + p[2] * p[2]
   d = Math.sqrt(d)
-  ra = Math.atan2(p[1], p[0]) * ($const.RTD * 3600. / 15.)
-  if (ra < 0.0) {
+  var ra = Math.atan2(p[1], p[0]) * ($const.RTD * 3600 / 15)
+  if (ra < 0) {
     ra += 86400.0
   }
-  dec = Math.asin(p[2] / d) * ($const.RTD * 3600.)
+  var dec = Math.asin(p[2] / d) * ($const.RTD * 3600)
 
   /* FIND CONSTELLATION SUCH THAT THE DECLINATION ENTERED IS HIGHER THAN
    THE LOWER BOUNDARY OF THE CONSTELLATION WHEN THE UPPER AND LOWER
    RIGHT ASCENSIONS FOR THE CONSTELLATION BOUND THE ENTERED RIGHT
    ASCENSION
    */
-  for (i = 0; i < this.bndries.length / 4; i++) {
-    k = i << 2
+  for (var i = 0; i < this.bndries.length / 4; i++) {
+    var k = i << 2
     if (ra >= this.bndries[k] && ra < this.bndries[k + 1] && dec > this.bndries[k + 2]) {
-      k = this.bndries [k + 3]
+      k = this.bndries[k + 3]
       return k
     }
   }

--- a/src/astronomy/moshier/deflection.js
+++ b/src/astronomy/moshier/deflection.js
@@ -1,7 +1,7 @@
 $ns.deflection = {}
 
 $ns.deflection.calc = function (p, q, e, result) {
-  var C = 1.974e-8 / ($const.SE * (1.0 + $const.qe))
+  var C = 1.974e-8 / ($const.SE * (1 + $const.qe))
   for (var i = 0; i < 3; i++) {
     $const.dp[i] = C * ($const.pq * e[i] / $const.SE - $const.ep * q[i] / $const.SO)
     p[i] += $const.dp[i]

--- a/src/astronomy/moshier/deflection.js
+++ b/src/astronomy/moshier/deflection.js
@@ -1,16 +1,13 @@
 $ns.deflection = {}
 
-$ns.deflection.calc = function (p, q, e, result) {
+$ns.deflection.calc = function (p, q, e) {
   var C = 1.974e-8 / ($const.SE * (1 + $const.qe))
   for (var i = 0; i < 3; i++) {
     $const.dp[i] = C * ($const.pq * e[i] / $const.SE - $const.ep * q[i] / $const.SO)
     p[i] += $const.dp[i]
   }
-
-  result = result || {}
-
-  result.sunElongation = Math.acos(-$const.ep) / $const.DTR
-  result.lightDeflection = $util.showcor(p, $const.dp)
-
-  return result
+  return {
+    sunElongation: Math.acos(-$const.ep) / $const.DTR,
+    lightDeflection: $util.showcor(p, $const.dp)
+  }
 }

--- a/src/astronomy/moshier/deflection.js
+++ b/src/astronomy/moshier/deflection.js
@@ -1,11 +1,8 @@
 $ns.deflection = {}
 
 $ns.deflection.calc = function (p, q, e, result) {
-  var C // double
-  var i // int
-
-  C = 1.974e-8 / ($const.SE * (1.0 + $const.qe))
-  for (i = 0; i < 3; i++) {
+  var C = 1.974e-8 / ($const.SE * (1.0 + $const.qe))
+  for (var i = 0; i < 3; i++) {
     $const.dp[i] = C * ($const.pq * e[i] / $const.SE - $const.ep * q[i] / $const.SO)
     p[i] += $const.dp[i]
   }

--- a/src/astronomy/moshier/delta.js
+++ b/src/astronomy/moshier/delta.js
@@ -90,10 +90,10 @@ $ns.delta.calc = function (date) {
     date.delta = $const.dtgiven
   } else if (date.j2000 > this.TABEND) {
     /* Extrapolate future values beyond the lookup table. */
-    if (date.j2000 > this.TABEND + 100.0) {
+    if (date.j2000 > this.TABEND + 100) {
       /* Morrison & Stephenson (2004) long-term curve fit. */
-      var B = (date.j2000 - 1820.0) / 100
-      date.delta = 32.0 * B * B - 20.0
+      var B = (date.j2000 - 1820) / 100
+      date.delta = 32 * B * B - 20
     } else {
       /* Cubic interpolation between last tabulated value
        and long-term curve evaluated at 100 years later. */
@@ -104,16 +104,16 @@ $ns.delta.calc = function (date) {
       var b = (this.dt[this.TABSIZ - 1] - this.dt[this.TABSIZ - 11]) / 1000
 
       /* Long-term curve 100 years hence. */
-      var B = (this.TABEND + 100.0 - 1820.0) / 100
-      var m0 = 32.0 * B * B - 20.0
+      var B = (this.TABEND + 100 - 1820) / 100
+      var m0 = 32 * B * B - 20
       /* Its slope. */
       var m1 = 0.64 * B
 
       /* Solve for remaining coefficients of an interpolation polynomial
        that agrees in value and slope at both ends of the 100-year
        interval. */
-      var d = 2.0e-6 * (50.0 * (m1 + b) - m0 + a)
-      var c = 1.0e-4 * (m0 - a - 100.0 * b - 1.0e6 * d)
+      var d = 2.0e-6 * (50 * (m1 + b) - m0 + a)
+      var c = 1.0e-4 * (m0 - a - 100 * b - 1.0e6 * d)
 
       /* Note, the polynomial coefficients do not depend on Y.
        A given tabulation and long-term formula
@@ -131,11 +131,11 @@ $ns.delta.calc = function (date) {
     }
   } else {
     /* Use Morrison and Stephenson (2004) prior to the year 1700. */
-    if (date.j2000 < 1700.0) {
-      if (date.j2000 <= -1000.0) {
+    if (date.j2000 < 1700) {
+      if (date.j2000 <= -1000) {
         /* Morrison and Stephenson long-term fit. */
-        var B = (date.j2000 - 1820.0) / 100
-        date.delta = 32.0 * B * B - 20.0
+        var B = (date.j2000 - 1820) / 100
+        date.delta = 32 * B * B - 20
       } else {
         /* Morrison and Stephenson recommend linear interpolation
          between tabulations. */
@@ -180,7 +180,7 @@ $ns.delta.calc = function (date) {
           for (var i = 0; i < 4; i++) {
             diff[i] = diff[i + 1] - diff[i]
           }
-          var B = 0.25 * p * (p - 1.0)
+          var B = 0.25 * p * (p - 1)
           date.delta += B * (diff[1] + diff[2])
 
           if (iy + 2 < this.TABSIZ) {
@@ -188,25 +188,25 @@ $ns.delta.calc = function (date) {
             for (var i = 0; i < 3; i++) {
               diff[i] = diff[i + 1] - diff[i]
             }
-            B = 2.0 * B / 3.0
+            B = 2 * B / 3
             date.delta += (p - 0.5) * B * diff[1]
             if (iy - 2 >= 0 && iy + 3 <= this.TABSIZ) {
               // Compute fourth differences
               for (var i = 0; i < 2; i++) {
                 diff[i] = diff[i + 1] - diff[i]
               }
-              B = 0.125 * B * (p + 1.0) * (p - 2.0)
+              B = 0.125 * B * (p + 1) * (p - 2)
               date.delta += B * (diff[0] + diff[1])
             }
           }
         }
       }
     }
-    date.delta /= 100.0
+    date.delta /= 100
   }
 
   date.terrestrial = date.julian
-  date.universal = date.terrestrial - date.delta / 86400.0
+  date.universal = date.terrestrial - date.delta / 86400
 
   return date.delta
 }

--- a/src/astronomy/moshier/delta.js
+++ b/src/astronomy/moshier/delta.js
@@ -84,9 +84,7 @@ $ns.delta.TABEND = 2011
 $ns.delta.TABSIZ = $ns.delta.TABEND - $ns.delta.TABSTART + 1
 
 $ns.delta.calc = function (date) {
-  var p, B // double
   var diff = [0, 0, 0, 0, 0, 0] // int
-  var i, iy, k // int
 
   if ($const.dtgiven) {
     date.delta = $const.dtgiven
@@ -94,30 +92,28 @@ $ns.delta.calc = function (date) {
     /* Extrapolate future values beyond the lookup table. */
     if (date.j2000 > this.TABEND + 100.0) {
       /* Morrison & Stephenson (2004) long-term curve fit. */
-      B = (date.j2000 - 1820.0) / 100
+      var B = (date.j2000 - 1820.0) / 100
       date.delta = 32.0 * B * B - 20.0
     } else {
-      var a, b, c, d, m0, m1 // double
-
       /* Cubic interpolation between last tabulated value
        and long-term curve evaluated at 100 years later. */
 
       /* Last tabulated delta T value. */
-      a = this.dt [this.TABSIZ - 1] / 100
+      var a = this.dt[this.TABSIZ - 1] / 100
       /* Approximate slope in past 10 years. */
-      b = (this.dt [this.TABSIZ - 1] - this.dt [this.TABSIZ - 11]) / 1000
+      var b = (this.dt[this.TABSIZ - 1] - this.dt[this.TABSIZ - 11]) / 1000
 
       /* Long-term curve 100 years hence. */
-      B = (this.TABEND + 100.0 - 1820.0) / 100
-      m0 = 32.0 * B * B - 20.0
+      var B = (this.TABEND + 100.0 - 1820.0) / 100
+      var m0 = 32.0 * B * B - 20.0
       /* Its slope. */
-      m1 = 0.64 * B
+      var m1 = 0.64 * B
 
       /* Solve for remaining coefficients of an interpolation polynomial
        that agrees in value and slope at both ends of the 100-year
        interval. */
-      d = 2.0e-6 * (50.0 * (m1 + b) - m0 + a)
-      c = 1.0e-4 * (m0 - a - 100.0 * b - 1.0e6 * d)
+      var d = 2.0e-6 * (50.0 * (m1 + b) - m0 + a)
+      var c = 1.0e-4 * (m0 - a - 100.0 * b - 1.0e6 * d)
 
       /* Note, the polynomial coefficients do not depend on Y.
        A given tabulation and long-term formula
@@ -130,7 +126,7 @@ $ns.delta.calc = function (date) {
        */
 
       /* Compute polynomial value at desired time. */
-      p = date.j2000 - this.TABEND
+      var p = date.j2000 - this.TABEND
       date.delta = a + p * (b + p * (c + p * d))
     }
   } else {
@@ -138,18 +134,17 @@ $ns.delta.calc = function (date) {
     if (date.j2000 < 1700.0) {
       if (date.j2000 <= -1000.0) {
         /* Morrison and Stephenson long-term fit. */
-        B = (date.j2000 - 1820.0) / 100
+        var B = (date.j2000 - 1820.0) / 100
         date.delta = 32.0 * B * B - 20.0
       } else {
         /* Morrison and Stephenson recommend linear interpolation
          between tabulations. */
-        iy = Math.floor(date.j2000)
+        var iy = Math.floor(date.j2000)
         iy = Math.floor((iy + 1000) / 100)
         /* Integer index into the table. */
-        B = -1000 + 100 * iy
+        var B = -1000 + 100 * iy
         /* Starting year of tabulated interval. */
-        p = this.m_s [iy]
-        date.delta = p + (date.j2000 - B) * (this.m_s [iy + 1] - p) / 100
+        date.delta = this.m_s[iy] + (date.j2000 - B) * (this.m_s[iy + 1] - this.m_s[iy]) / 100
       }
     } else {
       /* Besselian interpolation between tabulated values
@@ -158,22 +153,21 @@ $ns.delta.calc = function (date) {
        */
 
       /* Index into the table. */
-      p = Math.floor(date.j2000)
-      iy = Math.floor(p - this.TABSTART)
-      /* Zeroth order estimate is value at start of year
-       */
-      date.delta = this.dt [iy]
-      k = iy + 1
+      var p = Math.floor(date.j2000)
+      var iy = Math.floor(p - this.TABSTART)
+      /* Zeroth order estimate is value at start of year */
+      date.delta = this.dt[iy]
+      var k = iy + 1
       if (k < this.TABSIZ) {
         /* The fraction of tabulation interval */
         p = date.j2000 - p
 
         /* First order interpolated value */
-        date.delta += p * (this.dt [k] - this.dt [iy])
+        date.delta += p * (this.dt[k] - this.dt[iy])
         if (iy - 1 >= 0 && iy + 2 < this.TABSIZ) {
           // make table of first differences
           k = iy - 2
-          for (i = 0; i < 5; i++) {
+          for (var i = 0; i < 5; i++) {
             if (k < 0 || k + 1 >= this.TABSIZ) {
               diff[i] = 0
             } else {
@@ -183,22 +177,22 @@ $ns.delta.calc = function (date) {
           }
 
           // compute second differences
-          for (i = 0; i < 4; i++) {
+          for (var i = 0; i < 4; i++) {
             diff[i] = diff[i + 1] - diff[i]
           }
-          B = 0.25 * p * (p - 1.0)
+          var B = 0.25 * p * (p - 1.0)
           date.delta += B * (diff[1] + diff[2])
 
           if (iy + 2 < this.TABSIZ) {
             // Compute third differences
-            for (i = 0; i < 3; i++) {
+            for (var i = 0; i < 3; i++) {
               diff[i] = diff[i + 1] - diff[i]
             }
             B = 2.0 * B / 3.0
             date.delta += (p - 0.5) * B * diff[1]
             if (iy - 2 >= 0 && iy + 3 <= this.TABSIZ) {
               // Compute fourth differences
-              for (i = 0; i < 2; i++) {
+              for (var i = 0; i < 2; i++) {
                 diff[i] = diff[i + 1] - diff[i]
               }
               B = 0.125 * B * (p + 1.0) * (p - 2.0)

--- a/src/astronomy/moshier/diurnal.js
+++ b/src/astronomy/moshier/diurnal.js
@@ -7,7 +7,7 @@ $ns.diurnal = {
  * This formula is less rigorous than the method used for
  * annual aberration.  However, the correction is small.
  */
-$ns.diurnal.aberration = function (last, ra, dec, result) {
+$ns.diurnal.aberration = function (last, ra, dec) {
   var lha = last - ra
   var coslha = Math.cos(lha)
   var sinlha = Math.sin(lha)
@@ -18,30 +18,25 @@ $ns.diurnal.aberration = function (last, ra, dec, result) {
   var N = cosdec != 0.0 ? 1.5472e-6 * $const.trho * coslat * coslha / cosdec : 0.0
   var D = 1.5472e-6 * $const.trho * coslat * sinlha * sindec
 
-  result = result || {}
-  result.ra = ra
-  result.dec = dec
-  result.ra += N
-  result.dec += D
-  result.dRA = $const.RTS * N / 15
-  result.dDec = $const.RTS * D
-
-  return result
+  return {
+    ra: ra,
+    dec: dec,
+    ra: N,
+    dec: D,
+    dRA: $const.RTS * N / 15,
+    dDec: $const.RTS * D
+  }
 }
 
 /* Diurnal parallax, AA page D3 */
-$ns.diurnal.parallax = function (last, ra, dec, dist, result) {
+$ns.diurnal.parallax = function (last, ra, dec, dist) {
   var p = [], dp = [] // double
-
-  result = result || {}
 
   /* Don't bother with this unless the equatorial horizontal parallax
    * is at least 0.005"
    */
-  if (dist > 1758.8) {
-    result.ra = ra
-    result.dec = dec
-    return result
+  if (dist > 1758.8) return {
+    ra: ra, dec: dec
   }
 
   this.DISFAC = $const.au / (0.001 * $const.aearth)
@@ -72,8 +67,11 @@ $ns.diurnal.parallax = function (last, ra, dec, dist, result) {
   D = Math.sqrt(D)
   /* topocentric distance */
 
-  result.ra = $util.zatan2(x, y)
-  result.dec = Math.asin(z / D)
-  $util.showcor(p, dp, result)
-  return result
+  var result = $util.showcor(p, dp)
+  return {
+    ra: $util.zatan2(x, y),
+    dec: Math.asin(z / D),
+    dRA: result.dRA,
+    dDec: result.dDec
+  }
 }

--- a/src/astronomy/moshier/diurnal.js
+++ b/src/astronomy/moshier/diurnal.js
@@ -8,68 +8,57 @@ $ns.diurnal = {
  * annual aberration.  However, the correction is small.
  */
 $ns.diurnal.aberration = function (last, ra, dec, result) {
-  var lha, coslha, sinlha, cosdec, sindec // double
-  var coslat, N, D // double
+  var lha = last - ra
+  var coslha = Math.cos(lha)
+  var sinlha = Math.sin(lha)
+  var cosdec = Math.cos(dec)
+  var sindec = Math.sin(dec)
+  var coslat = Math.cos($const.DTR * $const.tlat)
+
+  var N = cosdec != 0.0 ? 1.5472e-6 * $const.trho * coslat * coslha / cosdec : 0.0
+  var D = 1.5472e-6 * $const.trho * coslat * sinlha * sindec
 
   result = result || {}
   result.ra = ra
   result.dec = dec
-
-  lha = last - result.ra
-  coslha = Math.cos(lha)
-  sinlha = Math.sin(lha)
-  cosdec = Math.cos(result.dec)
-  sindec = Math.sin(result.dec)
-  coslat = Math.cos($const.DTR * $const.tlat)
-
-  if (cosdec != 0.0)
-    N = 1.5472e-6 * $const.trho * coslat * coslha / cosdec
-  else
-    N = 0.0
   result.ra += N
-
-  D = 1.5472e-6 * $const.trho * coslat * sinlha * sindec
   result.dec += D
-
   result.dRA = $const.RTS * N / 15.0
   result.dDec = $const.RTS * D
 
   return result
 }
 
-/* Diurnal parallax, AA page D3
- */
+/* Diurnal parallax, AA page D3 */
 $ns.diurnal.parallax = function (last, ra, dec, dist, result) {
-  var cosdec, sindec, coslat, sinlat // double
-  var p = [], dp = [], x, y, z, D // double
+  var p = [], dp = [] // double
 
   result = result || {}
-  result.ra = ra
-  result.dec = dec
 
   /* Don't bother with this unless the equatorial horizontal parallax
    * is at least 0.005"
    */
   if (dist > 1758.8) {
+    result.ra = ra
+    result.dec = dec
     return result
   }
 
   this.DISFAC = $const.au / (0.001 * $const.aearth)
-  cosdec = Math.cos(result.dec)
-  sindec = Math.sin(result.dec)
+  var cosdec = Math.cos(dec)
+  var sindec = Math.sin(dec)
 
-  /* Observer's astronomical latitude
-   */
-  x = $const.tlat * $const.DTR
-  coslat = Math.cos(x)
-  sinlat = Math.sin(x)
+  /* Observer's astronomical latitude */
+  var x = $const.tlat * $const.DTR
+  var coslat = Math.cos(x)
+  var sinlat = Math.sin(x)
 
   /* Convert to equatorial rectangular coordinates
    * in which unit distance = earth radius
    */
-  D = dist * this.DISFAC
-  p[0] = D * cosdec * Math.cos(result.ra)
-  p[1] = D * cosdec * Math.sin(result.ra)
+  var D = dist * this.DISFAC
+  p[0] = D * cosdec * Math.cos(ra)
+  p[1] = D * cosdec * Math.sin(ra)
   p[2] = D * sindec
 
   dp[0] = -$const.trho * coslat * Math.cos(last)
@@ -77,13 +66,12 @@ $ns.diurnal.parallax = function (last, ra, dec, dist, result) {
   dp[2] = -$const.trho * sinlat
 
   x = p[0] + dp[0]
-  y = p[1] + dp[1]
-  z = p[2] + dp[2]
+  var y = p[1] + dp[1]
+  var z = p[2] + dp[2]
   D = x * x + y * y + z * z
   D = Math.sqrt(D)
   /* topocentric distance */
 
-  /* recompute ra and dec */
   result.ra = $util.zatan2(x, y)
   result.dec = Math.asin(z / D)
   $util.showcor(p, dp, result)

--- a/src/astronomy/moshier/diurnal.js
+++ b/src/astronomy/moshier/diurnal.js
@@ -23,7 +23,7 @@ $ns.diurnal.aberration = function (last, ra, dec, result) {
   result.dec = dec
   result.ra += N
   result.dec += D
-  result.dRA = $const.RTS * N / 15.0
+  result.dRA = $const.RTS * N / 15
   result.dDec = $const.RTS * D
 
   return result

--- a/src/astronomy/moshier/epsilon.js
+++ b/src/astronomy/moshier/epsilon.js
@@ -9,12 +9,10 @@ $ns.epsilon = {
 }
 
 $ns.epsilon.calc = function (date) {
-  var T // double
-
   if (date.julian == this.jdeps) {
     return
   }
-  T = (date.julian - 2451545.0) / 36525.0
+  var T = (date.julian - 2451545.0) / 36525.0
 
   /* DE403 values. */
   T /= 10.0

--- a/src/astronomy/moshier/epsilon.js
+++ b/src/astronomy/moshier/epsilon.js
@@ -12,10 +12,10 @@ $ns.epsilon.calc = function (date) {
   if (date.julian == this.jdeps) {
     return
   }
-  var T = (date.julian - 2451545.0) / 36525.0
+  var T = (date.julian - 2451545) / 36525
 
   /* DE403 values. */
-  T /= 10.0
+  T /= 10
   this.eps = (((((((((2.45e-10 * T + 5.79e-9) * T + 2.787e-7) * T
     + 7.12e-7) * T - 3.905e-5) * T - 2.4967e-3) * T
     - 5.138e-3) * T + 1.9989) * T - 0.0175) * T - 468.33960) * T

--- a/src/astronomy/moshier/fk4fk5.js
+++ b/src/astronomy/moshier/fk4fk5.js
@@ -78,7 +78,7 @@ $ns.fk4fk5.calc = function (p, m, el) {
   el.raMotion = (p[0] * m[1] - p[1] * m[0]) / ($const.RTS * b)
   el.decMotion = (m[2] * b - p[2] * (p[0] * m[0] + p[1] * m[1])) / ($const.RTS * c * Math.sqrt(b))
 
-  if (el.parallax > 0.0) {
+  if (el.parallax > 0) {
     c = 0.0
     for (var i = 0; i < 3; i++) {
       c += p[i] * m[i]

--- a/src/astronomy/moshier/fk4fk5.js
+++ b/src/astronomy/moshier/fk4fk5.js
@@ -67,9 +67,8 @@ $ns.fk4fk5.calc = function (p, m, el) {
    * in radian measure.
    */
   b = p[0] * p[0] + p[1] * p[1]
-  a = b + p[2] * p[2]
-  var c = a
-  a = Math.sqrt(a)
+  var c = b + p[2] * p[2]
+  a = Math.sqrt(c)
 
   el.ra = $util.zatan2(p[0], p[1])
   el.dec = Math.asin(p[2] / a)

--- a/src/astronomy/moshier/fk4fk5.js
+++ b/src/astronomy/moshier/fk4fk5.js
@@ -1,6 +1,5 @@
 $ns.fk4fk5 = {
-  /* Factors to eliminate E terms of aberration
-   */
+  /* Factors to eliminate E terms of aberration */
   A: [-1.62557e-6, -3.1919e-7, -1.3843e-7],
   Ad: [1.244e-3, -1.579e-3, -6.60e-4],
 
@@ -28,25 +27,21 @@ $ns.fk4fk5 = {
  * AA page B58.
  */
 $ns.fk4fk5.calc = function (p, m, el) {
-  var a, b, c // double
-  var u, v // double array
   var R = [] // double
-  var i, j // int
 
   /* Note the direction vector and motion vector
    * are already supplied by rstar.c.
    */
-  a = 0.0
-  b = 0.0
-  for (i = 0; i < 3; i++) {
+  var a = 0.0
+  var b = 0.0
+  for (var i = 0; i < 3; i++) {
     m[i] *= $const.RTS
     /* motion must be in arc seconds per century */
     a += this.A[i] * p[i]
     b += this.Ad[i] * p[i]
   }
-  /* Remove E terms of aberration from FK4
-   */
-  for (i = 0; i < 3; i++) {
+  /* Remove E terms of aberration from FK4 */
+  for (var i = 0; i < 3; i++) {
     R[i] = p[i] - this.A[i] + a * p[i]
     R[i + 3] = m[i] - this.Ad[i] + b * p[i]
   }
@@ -54,14 +49,12 @@ $ns.fk4fk5.calc = function (p, m, el) {
   var u_i = 0
   var v_i = 0
 
-  /* Perform matrix multiplication
-   */
-  v = this.Mat
-  for (i = 0; i < 6; i++) {
+  /* Perform matrix multiplication */
+  var v = this.Mat
+  for (var i = 0; i < 6; i++) {
     a = 0.0
-    u = R
-    for (j = 0; j < 6; j++) {
-      a += u [u_i++] * v [v_i++]//*u++ * *v++;
+    for (var j = 0; j < 6; j++) {
+      a += R[u_i++] * v[v_i++] // *u++ * *v++;
     }
     if (i < 3) {
       p[i] = a
@@ -75,7 +68,7 @@ $ns.fk4fk5.calc = function (p, m, el) {
    */
   b = p[0] * p[0] + p[1] * p[1]
   a = b + p[2] * p[2]
-  c = a
+  var c = a
   a = Math.sqrt(a)
 
   el.ra = $util.zatan2(p[0], p[1])
@@ -87,7 +80,7 @@ $ns.fk4fk5.calc = function (p, m, el) {
 
   if (el.parallax > 0.0) {
     c = 0.0
-    for (i = 0; i < 3; i++) {
+    for (var i = 0; i < 3; i++) {
       c += p[i] * m[i]
     }
 

--- a/src/astronomy/moshier/gplan.js
+++ b/src/astronomy/moshier/gplan.js
@@ -37,9 +37,7 @@ $ns.gplan = {
 
 }
 
-/*
- Routines to chew through tables of perturbations.
-*/
+/* Routines to chew through tables of perturbations. */
 $ns.gplan.calc = function (date, body_ptable, polar) {
   var T = (date.julian - $const.j2000) / body_ptable.timescale
   var n = body_ptable.maxargs

--- a/src/astronomy/moshier/gplan.js
+++ b/src/astronomy/moshier/gplan.js
@@ -1,7 +1,7 @@
 $ns.gplan = {
-  /* From Simon et al (1994)  */
+  /* From Simon et al (1994) */
   freqs: [
-    /* Arc sec per 10000 Julian years.  */
+    /* Arc sec per 10000 Julian years. */
     53810162868.8982,
     21066413643.3548,
     12959774228.3429,
@@ -14,7 +14,7 @@ $ns.gplan = {
   ],
 
   phases: [
-    /* Arc sec.  */
+    /* Arc sec. */
     252.25090552 * 3600.,
     181.97980085 * 3600.,
     100.46645683 * 3600.,
@@ -41,35 +41,28 @@ $ns.gplan = {
  Routines to chew through tables of perturbations.
 */
 $ns.gplan.calc = function (date, body_ptable, polar) {
-  var su, cu, sv, cv, T // double
-  var t, sl, sb, sr // double
-  var i, j, k, m, n, k1, ip, np, nt // int
-  var p // char array
-  var pl // double array
-  var pb // double array
-  var pr // double array
-
-  T = (date.julian - $const.j2000) / body_ptable.timescale
-  n = body_ptable.maxargs
-  /* Calculate sin( i*MM ), etc. for needed multiple angles.  */
-  for (i = 0; i < n; i++) {
-    if ((j = body_ptable.max_harmonic[i]) > 0) {
-      sr = ($util.mods3600(this.freqs [i] * T) + this.phases [i]) * $const.STR
+  var T = (date.julian - $const.j2000) / body_ptable.timescale
+  var n = body_ptable.maxargs
+  /* Calculate sin( i*MM ), etc. for needed multiple angles. */
+  for (var i = 0; i < n; i++) {
+    var j = body_ptable.max_harmonic[i]
+    if (j > 0) {
+      sr = ($util.mods3600(this.freqs[i] * T) + this.phases[i]) * $const.STR
       this.sscc(i, sr, j)
     }
   }
 
   /* Point to start of table of arguments. */
-  p = body_ptable.arg_tbl
+  var p = body_ptable.arg_tbl
 
-  /* Point to tabulated cosine and sine amplitudes.  */
-  pl = body_ptable.lon_tbl
-  pb = body_ptable.lat_tbl
-  pr = body_ptable.rad_tbl
+  /* Point to tabulated cosine and sine amplitudes. */
+  var pl = body_ptable.lon_tbl
+  var pb = body_ptable.lat_tbl
+  var pr = body_ptable.rad_tbl
 
-  sl = 0.0
-  sb = 0.0
-  sr = 0.0
+  var sl = 0.0
+  var sb = 0.0
+  var sr = 0.0
 
   var p_i = 0
   var pl_i = 0
@@ -79,118 +72,112 @@ $ns.gplan.calc = function (date, body_ptable, polar) {
   for (; ;) {
     /* argument of sine and cosine */
     /* Number of periodic arguments. */
-    np = p [p_i++] // np = *p++
+    var np = p[p_i++] // np = *p++
     if (np < 0) {
       break
     }
-    if (np == 0) { /* It is a polynomial term.  */
-      nt = p [p_i++] // nt = *p++
+    if (np == 0) { /* It is a polynomial term. */
+      var nt = p[p_i++] // nt = *p++
       /* Longitude polynomial. */
-      cu = pl [pl_i++] // cu = *pl++;
-      for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pl [pl_i++] //*pl++;
+      var cu = pl[pl_i++] // cu = *pl++;
+      for (var ip = 0; ip < nt; ip++) {
+        cu = cu * T + pl[pl_i++] // *pl++;
       }
       sl += $util.mods3600(cu)
       /* Latitude polynomial. */
-      cu = pb [pb_i++]//*pb++;
+      cu = pb[pb_i++] // *pb++;
       for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pb [pb_i++] //*pb++;
+        cu = cu * T + pb[pb_i++] // *pb++;
       }
       sb += cu
       /* Radius polynomial. */
-      cu = pr [pr_i++] //*pr++;
-      for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pr [pr_i++] //*pr++;
+      cu = pr[pr_i++] // *pr++;
+      for (var ip = 0; ip < nt; ip++) {
+        cu = cu * T + pr[pr_i++] // *pr++;
       }
       sr += cu
       continue
     }
-    k1 = 0
-    cv = 0.0
-    sv = 0.0
-    for (ip = 0; ip < np; ip++) {
-      /* What harmonic.  */
-      j = p [p_i++] //*p++;
-      /* Which planet.  */
-      m = p [p_i++] - 1 // *p++ - 1
+    var k1 = 0
+    var cv = 0.0
+    var sv = 0.0
+    for (var ip = 0; ip < np; ip++) {
+      /* What harmonic. */
+      var j = p[p_i++] // *p++;
+      /* Which planet. */
+      var m = p[p_i++] - 1 // *p++ - 1
       if (j) {
-        k = j
-        if (j < 0)
-          k = -k
+        var k = j < 0 ? -j : j
         k -= 1
-        su = this.ss[m][k]
+        var su = this.ss[m][k]
         /* sin(k*angle) */
         if (j < 0)
           su = -su
-        cu = this.cc[m][k]
+        var cu = this.cc[m][k]
         if (k1 == 0) { /* set first angle */
           sv = su
           cv = cu
           k1 = 1
         }
         else { /* combine angles */
-          t = su * cv + cu * sv
+          var tmp = su * cv + cu * sv
           cv = cu * cv - su * sv
-          sv = t
+          sv = tmp
         }
       }
     }
-    /* Highest power of T.  */
-    nt = p [p_i++] //*p++;
-    /* Longitude. */
-    cu = pl [pl_i++] //*pl++;
-    su = pl [pl_i++] //*pl++;
-    for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pl [pl_i++] //*pl++;
-      su = su * T + pl [pl_i++] //*pl++;
+    /* Highest power of T. */
+    var nt = p[p_i++] // *p++;
+    /* Longitude */
+    var cu = pl[pl_i++] // *pl++;
+    var su = pl[pl_i++] // *pl++;
+    for (var ip = 0; ip < nt; ip++) {
+      cu = cu * T + pl[pl_i++] // *pl++;
+      su = su * T + pl[pl_i++] // *pl++;
     }
     sl += cu * cv + su * sv
-    /* Latitiude. */
-    cu = pb [pb_i++] //*pb++;
-    su = pb [pb_i++] //*pb++;
-    for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pb [pb_i++] //*pb++;
-      su = su * T + pb [pb_i++] //*pb++;
+    /* Latitiude */
+    cu = pb[pb_i++] // *pb++;
+    su = pb[pb_i++] // *pb++;
+    for (var ip = 0; ip < nt; ip++) {
+      cu = cu * T + pb[pb_i++] // *pb++;
+      su = su * T + pb[pb_i++] // *pb++;
     }
     sb += cu * cv + su * sv
-    /* Radius. */
-    cu = pr [pr_i++] //*pr++;
-    su = pr [pr_i++] //*pr++;
-    for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pr [pr_i++] //*pr++;
-      su = su * T + pr [pr_i++] //*pr++;
+    /* Radius */
+    cu = pr[pr_i++] // *pr++;
+    su = pr[pr_i++] // *pr++;
+    for (var ip = 0; ip < nt; ip++) {
+      cu = cu * T + pr[pr_i++] // *pr++;
+      su = su * T + pr[pr_i++] // *pr++;
     }
     sr += cu * cv + su * sv
   }
 
-  polar [0] = $const.STR * sl
-  polar [1] = $const.STR * sb
-  polar [2] = $const.STR * body_ptable.distance * sr + body_ptable.distance
+  polar[0] = $const.STR * sl
+  polar[1] = $const.STR * sb
+  polar[2] = $const.STR * body_ptable.distance * sr + body_ptable.distance
 }
 
 /* Prepare lookup table of sin and cos ( i*Lj )
  * for required multiple angles
  */
 $ns.gplan.sscc = function (k, arg, n) {
-  var cu, su, cv, sv, s // double
-  var i // int
-
-  su = Math.sin(arg)
-  cu = Math.cos(arg)
+  var su = Math.sin(arg)
+  var cu = Math.cos(arg)
   this.ss[k] = []
   this.cc[k] = []
-
   this.ss[k][0] = su
   /* sin(L) */
   this.cc[k][0] = cu
   /* cos(L) */
-  sv = 2.0 * su * cu
-  cv = cu * cu - su * su
+  var sv = 2.0 * su * cu
+  var cv = cu * cu - su * su
   this.ss[k][1] = sv
   /* sin(2L) */
   this.cc[k][1] = cv
-  for (i = 2; i < n; i++) {
-    s = su * cv + cu * sv
+  for (var i = 2; i < n; i++) {
+    var s = su * cv + cu * sv
     cv = cu * cv - su * sv
     sv = s
     this.ss[k][i] = sv
@@ -199,19 +186,17 @@ $ns.gplan.sscc = function (k, arg, n) {
   }
 }
 
-/* Compute mean elements at Julian date J.  */
+/* Compute mean elements at Julian date J. */
 $ns.gplan.meanElements = function (date) {
-  var x, T, T2 // double
-
-  /* Time variables.  T is in Julian centuries.  */
-  T = (date.julian - 2451545.0) / 36525.0
-  T2 = T * T
+  /* Time variables. T is in Julian centuries. */
+  var T = (date.julian - 2451545.0) / 36525.0
+  var T2 = T * T
 
   /* Mean longitudes of planets (Simon et al, 1994)
    .047" subtracted from constant term for offset to DE403 origin. */
 
   /* Mercury */
-  x = $util.mods3600(538101628.6889819 * T + 908103.213)
+  var x = $util.mods3600(538101628.6889819 * T + 908103.213)
   x += (6.39e-6 * T
     - 0.0192789) * T2
   this.Args[0] = $const.STR * x
@@ -263,7 +248,7 @@ $ns.gplan.meanElements = function (date) {
     + (-0.00000895 * T + 0.0021103) * T2
   this.Args[7] = $const.STR * x
 
-  /* Copied from cmoon.c, DE404 version.  */
+  /* Copied from cmoon.c, DE404 version. */
   /* Mean elongation of moon = D */
   x = $util.mods3600(1.6029616009939659e+09 * T + 1.0722612202445078e+06)
   x += (((((-3.207663637426e-013 * T
@@ -312,7 +297,7 @@ $ns.gplan.meanElements = function (date) {
   /* l, t^2 */
   this.Args[12] = $const.STR * x
 
-  /* Mean longitude of moon, re mean ecliptic and equinox of date = L  */
+  /* Mean longitude of moon, re mean ecliptic and equinox of date = L */
   x = $util.mods3600(1.7325643720442266e+09 * T + 7.8593980921052420e+05)
   x += (((((7.200592540556e-014 * T
     + 2.235210987108e-010) * T
@@ -324,7 +309,7 @@ $ns.gplan.meanElements = function (date) {
   this.LP_equinox = x
   this.Args[13] = $const.STR * x
 
-  /* Precession of the equinox  */
+  /* Precession of the equinox */
   x = (((((((((-8.66e-20 * T - 4.759e-17) * T
     + 2.424e-15) * T
     + 1.3095e-12) * T
@@ -334,13 +319,13 @@ $ns.gplan.meanElements = function (date) {
     + 0.000076) * T
     + 1.105414) * T
     + 5028.791959) * T
-  /* Moon's longitude re fixed J2000 equinox.  */
+  /* Moon's longitude re fixed J2000 equinox. */
   /*
    Args[13] -= x;
    */
   this.pA_precession = $const.STR * x
 
-  /* Free librations.  */
+  /* Free librations. */
   /* longitudinal libration 2.891725 years */
   x = $util.mods3600(4.48175409e7 * T + 8.060457e5)
   this.Args[14] = $const.STR * x
@@ -355,38 +340,30 @@ $ns.gplan.meanElements = function (date) {
 
 /* Generic program to accumulate sum of trigonometric series
  in three variables (e.g., longitude, latitude, radius)
- of the same list of arguments.  */
+ of the same list of arguments. */
 $ns.gplan.calc3 = function (date, body_ptable, polar, body_number) {
-  var i, j, k, m, n, k1, ip, np, nt // int
-  var p // int array
-  var pl // double array
-  var pb // double array
-  var pr // double array
-
-  var su, cu, sv, cv // double
-  var T, t, sl, sb, sr // double
-
   this.meanElements(date)
 
-  T = (date.julian - $const.j2000) / body_ptable.timescale
-  n = body_ptable.maxargs
-  /* Calculate sin( i*MM ), etc. for needed multiple angles.  */
-  for (i = 0; i < n; i++) {
-    if ((j = body_ptable.max_harmonic [i]) > 0) {
-      this.sscc(i, this.Args [i], j)
+  var T = (date.julian - $const.j2000) / body_ptable.timescale
+  var n = body_ptable.maxargs
+  /* Calculate sin( i*MM ), etc. for needed multiple angles. */
+  for (var i = 0; i < n; i++) {
+    var j = body_ptable.max_harmonic[i]
+    if (j > 0) {
+      this.sscc(i, this.Args[i], j)
     }
   }
 
   /* Point to start of table of arguments. */
-  p = body_ptable.arg_tbl
-  /* Point to tabulated cosine and sine amplitudes.  */
-  pl = body_ptable.lon_tbl
-  pb = body_ptable.lat_tbl
-  pr = body_ptable.rad_tbl
+  var p = body_ptable.arg_tbl
+  /* Point to tabulated cosine and sine amplitudes. */
+  var pl = body_ptable.lon_tbl
+  var pb = body_ptable.lat_tbl
+  var pr = body_ptable.rad_tbl
 
-  sl = 0.0
-  sb = 0.0
-  sr = 0.0
+  var sl = 0.0
+  var sb = 0.0
+  var sr = 0.0
 
   var p_i = 0
   var pl_i = 0
@@ -396,92 +373,89 @@ $ns.gplan.calc3 = function (date, body_ptable, polar, body_number) {
   for (; ;) {
     /* argument of sine and cosine */
     /* Number of periodic arguments. */
-    np = p [p_i++] //*p++;
+    var np = p[p_i++] // *p++;
     if (np < 0)
       break
-    if (np == 0) { /* It is a polynomial term.  */
-      nt = p [p_i++] //*p++;
+    if (np == 0) { /* It is a polynomial term. */
+      var nt = p[p_i++] // *p++;
       /* "Longitude" polynomial (phi). */
-      cu = pl [pl_i++] //*pl++;
-      for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pl [pl_i++] //*pl++;
+      var cu = pl[pl_i++] // *pl++;
+      for (var ip = 0; ip < nt; ip++) {
+        cu = cu * T + pl[pl_i++] // *pl++;
       }
       /* sl += mods3600 (cu); */
       sl += cu
       /* "Latitude" polynomial (theta). */
-      cu = pb [pb_i++] //*pb++;
+      cu = pb[pb_i++] // *pb++;
       for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pb [pb_i++] //*pb++;
+        cu = cu * T + pb[pb_i++] // *pb++;
       }
       sb += cu
       /* Radius polynomial (psi). */
-      cu = pr [pr_i++] //*pr++;
+      cu = pr[pr_i++] // *pr++;
       for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pr [pr_i++] //*pr++;
+        cu = cu * T + pr[pr_i++] // *pr++;
       }
       sr += cu
       continue
     }
-    k1 = 0
-    cv = 0.0
-    sv = 0.0
-    for (ip = 0; ip < np; ip++) {
-      /* What harmonic.  */
-      j = p [p_i++] //*p++;
-      /* Which planet.  */
-      m = p [p_i++] - 1 //*p++ - 1;
+    var k1 = 0
+    var cv = 0.0
+    var sv = 0.0
+    for (var ip = 0; ip < np; ip++) {
+      /* What harmonic. */
+      var j = p[p_i++] // *p++;
+      /* Which planet. */
+      var m = p[p_i++] - 1 // *p++ - 1;
       if (j) {
-        /* k = abs (j); */
-        if (j < 0)
-          k = -j
-        else
-          k = j
+        /* var k = abs (j); */
+        var k = j < 0 ? -j : j
         k -= 1
-        su = this.ss[m][k]
+        var su = this.ss[m][k]
         /* sin(k*angle) */
         if (j < 0)
           su = -su
-        cu = this.cc[m][k]
+        var cu = this.cc[m][k]
         if (k1 == 0) { /* set first angle */
           sv = su
           cv = cu
           k1 = 1
         }
         else { /* combine angles */
-          t = su * cv + cu * sv
+          var tmp = su * cv + cu * sv
           cv = cu * cv - su * sv
-          sv = t
+          sv = tmp
         }
       }
     }
-    /* Highest power of T.  */
-    nt = p [p_i++] //*p++;
+    /* Highest power of T. */
+    var nt = p[p_i++] // *p++;
     /* Longitude. */
-    cu = pl [pl_i++] //*pl++;
-    su = pl [pl_i++] //*pl++;
-    for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pl [pl_i++] //*pl++;
-      su = su * T + pl [pl_i++] //*pl++;
+    var cu = pl[pl_i++] // *pl++;
+    var su = pl[pl_i++] // *pl++;
+    for (var ip = 0; ip < nt; ip++) {
+      cu = cu * T + pl[pl_i++] // *pl++;
+      su = su * T + pl[pl_i++] // *pl++;
     }
     sl += cu * cv + su * sv
     /* Latitiude. */
-    cu = pb [pb_i++] //*pb++;
-    su = pb [pb_i++] //*pb++;
+    cu = pb[pb_i++] // *pb++;
+    su = pb[pb_i++] // *pb++;
     for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pb [pb_i++] //*pb++;
-      su = su * T + pb [pb_i++] //*pb++;
+      cu = cu * T + pb[pb_i++] // *pb++;
+      su = su * T + pb[pb_i++] // *pb++;
     }
     sb += cu * cv + su * sv
     /* Radius. */
-    cu = pr [pr_i++] //*pr++;
-    su = pr [pr_i++] //*pr++;
+    cu = pr[pr_i++] // *pr++;
+    su = pr[pr_i++] // *pr++;
     for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pr [pr_i++] //*pr++;
-      su = su * T + pr [pr_i++] //*pr++;
+      cu = cu * T + pr[pr_i++] // *pr++;
+      su = su * T + pr[pr_i++] // *pr++;
     }
     sr += cu * cv + su * sv
   }
-  t = body_ptable.trunclvl
+  var t = body_ptable.trunclvl
   polar[0] = this.Args[body_number - 1] + $const.STR * t * sl
   polar[1] = $const.STR * t * sb
   polar[2] = body_ptable.distance * (1.0 + $const.STR * t * sr)
@@ -489,216 +463,193 @@ $ns.gplan.calc3 = function (date, body_ptable, polar, body_number) {
 
 /* Generic program to accumulate sum of trigonometric series
  in two variables (e.g., longitude, radius)
- of the same list of arguments.  */
+ of the same list of arguments. */
 $ns.gplan.calc2 = function (date, body_ptable, polar) {
-  var i, j, k, m, n, k1, ip, np, nt // int
-  var p // int array
-  var pl // double array
-  var pr // double array
-
-  var su, cu, sv, cv // double
-  var T, t, sl, sr // double
-
   this.meanElements(date)
 
-  T = (date.julian - $const.j2000) / body_ptable.timescale
-  n = body_ptable.maxargs
-  /* Calculate sin( i*MM ), etc. for needed multiple angles.  */
-  for (i = 0; i < n; i++) {
-    if ((j = body_ptable.max_harmonic[i]) > 0) {
+  var T = (date.julian - $const.j2000) / body_ptable.timescale
+  var n = body_ptable.maxargs
+  /* Calculate sin( i*MM ), etc. for needed multiple angles. */
+  for (var i = 0; i < n; i++) {
+    var j = body_ptable.max_harmonic[i]
+    if (j > 0) {
       this.sscc(i, this.Args[i], j)
     }
   }
 
   /* Point to start of table of arguments. */
-  p = body_ptable.arg_tbl
-  /* Point to tabulated cosine and sine amplitudes.  */
-  pl = body_ptable.lon_tbl
-  pr = body_ptable.rad_tbl
+  var p = body_ptable.arg_tbl
+  /* Point to tabulated cosine and sine amplitudes. */
+  var pl = body_ptable.lon_tbl
+  var pr = body_ptable.rad_tbl
 
   var p_i = 0
   var pl_i = 0
   var pr_i = 0
-
-  sl = 0.0
-  sr = 0.0
+  var sl = 0.0
+  var sr = 0.0
 
   for (; ;) {
     /* argument of sine and cosine */
     /* Number of periodic arguments. */
-    np = p [p_i++] //*p++;
+    var np = p[p_i++] // *p++;
     if (np < 0)
       break
     if (np == 0) { /* It is a polynomial term. */
-      nt = p [p_i++] //*p++;
+      var nt = p[p_i++] // *p++;
       /* Longitude polynomial. */
-      cu = pl [pl_i++] //*pl++;
+      var cu = pl[pl_i++] // *pl++;
       for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pl [pl_i++] //*pl++;
+        cu = cu * T + pl[pl_i++] // *pl++;
       }
       /* sl += mods3600 (cu); */
       sl += cu
       /* Radius polynomial. */
-      cu = pr [pr_i++] //*pr++;
+      cu = pr[pr_i++] // *pr++;
       for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pr [pr_i++] //*pr++;
+        cu = cu * T + pr[pr_i++] // *pr++;
       }
       sr += cu
       continue
     }
-    k1 = 0
-    cv = 0.0
-    sv = 0.0
-    for (ip = 0; ip < np; ip++) {
-      /* What harmonic.  */
-      j = p [p_i++] //*p++;
-      /* Which planet.  */
-      m = p [p_i++] - 1 //*p++ - 1;
+    var k1 = 0
+    var cv = 0.0
+    var sv = 0.0
+    for (var ip = 0; ip < np; ip++) {
+      /* What harmonic. */
+      var j = p[p_i++] // *p++;
+      /* Which planet. */
+      var m = p[p_i++] - 1 // *p++ - 1;
       if (j) {
-        /* k = abs (j); */
-        if (j < 0)
-          k = -j
-        else
-          k = j
+        /* var k = abs (j); */
+        var k = j < 0 ? -j : j
         k -= 1
-        su = this.ss[m][k]
+        var su = this.ss[m][k]
         /* sin(k*angle) */
         if (j < 0)
           su = -su
-        cu = this.cc[m][k]
+        var cu = this.cc[m][k]
         if (k1 == 0) { /* set first angle */
           sv = su
           cv = cu
           k1 = 1
         }
         else { /* combine angles */
-          t = su * cv + cu * sv
+          var tmp = su * cv + cu * sv
           cv = cu * cv - su * sv
-          sv = t
+          sv = tmp
         }
       }
     }
-    /* Highest power of T.  */
-    nt = p [p_i++] //*p++;
+    /* Highest power of T. */
+    var nt = p[p_i++] // *p++;
     /* Longitude. */
-    cu = pl [pl_i++] //*pl++;
-    su = pl [pl_i++] //*pl++;
-    for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pl [pl_i++] //*pl++;
-      su = su * T + pl [pl_i++] //*pl++;
+    var cu = pl[pl_i++] // *pl++;
+    var su = pl[pl_i++] // *pl++;
+    for (var ip = 0; ip < nt; ip++) {
+      cu = cu * T + pl[pl_i++] // *pl++;
+      su = su * T + pl[pl_i++] // *pl++;
     }
     sl += cu * cv + su * sv
     /* Radius. */
-    cu = pr [pr_i++] //*pr++;
-    su = pr [pr_i++] //*pr++;
-    for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pr [pr_i++] //*pr++;
-      su = su * T + pr [pr_i++] //*pr++;
+    cu = pr[pr_i++] // *pr++;
+    su = pr[pr_i++] // *pr++;
+    for (var ip = 0; ip < nt; ip++) {
+      cu = cu * T + pr[pr_i++] // *pr++;
+      su = su * T + pr[pr_i++] // *pr++;
     }
     sr += cu * cv + su * sv
   }
-  t = body_ptable.trunclvl
+  var t = body_ptable.trunclvl
   polar[0] = t * sl
   polar[2] = t * sr
 }
 
 /* Generic program to accumulate sum of trigonometric series
- in one variable.  */
+ in one variable. */
 $ns.gplan.calc1 = function (date, body_ptable) {
-  var i, j, k, m, k1, ip, np, nt // int
-  var p // int array
-  var pl // double array
-
-  var su, cu, sv, cv // double
-  var T, t, sl // double
-
-  T = (date.julian - $const.j2000) / body_ptable.timescale
+  var T = (date.julian - $const.j2000) / body_ptable.timescale
   this.meanElements(date)
-  /* Calculate sin( i*MM ), etc. for needed multiple angles.  */
-  for (i = 0; i < this.Args.length; i++) {
-    if ((j = body_ptable.max_harmonic[i]) > 0) {
+  /* Calculate sin( i*MM ), etc. for needed multiple angles. */
+  for (var i = 0; i < this.Args.length; i++) {
+    var j = body_ptable.max_harmonic[i]
+    if (j > 0) {
       this.sscc(i, this.Args[i], j)
     }
   }
 
   /* Point to start of table of arguments. */
-  p = body_ptable.arg_tbl
-  /* Point to tabulated cosine and sine amplitudes.  */
-  pl = body_ptable.lon_tbl
+  var p = body_ptable.arg_tbl
+  /* Point to tabulated cosine and sine amplitudes. */
+  var pl = body_ptable.lon_tbl
 
-  sl = 0.0
-
+  var sl = 0.0
   var p_i = 0
   var pl_i = 0
 
   for (; ;) {
     /* argument of sine and cosine */
     /* Number of periodic arguments. */
-    np = p [p_i++] //*p++;
+    var np = p[p_i++] // *p++;
     if (np < 0)
       break
-    if (np == 0) { /* It is a polynomial term.  */
-      nt = p [p_i++] //*p++;
-      cu = pl [pl_i++] //*pl++;
-      for (ip = 0; ip < nt; ip++) {
-        cu = cu * T + pl [pl_i++] //*pl++;
+    if (np == 0) { /* It is a polynomial term. */
+      var nt = p[p_i++] // *p++;
+      var cu = pl[pl_i++] // *pl++;
+      for (var ip = 0; ip < nt; ip++) {
+        cu = cu * T + pl[pl_i++] // *pl++;
       }
       /* sl += mods3600 (cu); */
       sl += cu
       continue
     }
-    k1 = 0
-    cv = 0.0
-    sv = 0.0
-    for (ip = 0; ip < np; ip++) {
+    var k1 = 0
+    var cv = 0.0
+    var sv = 0.0
+    for (var ip = 0; ip < np; ip++) {
       /* What harmonic. */
-      j = p [p_i++] //*p++;
+      var j = p[p_i++] // *p++;
       /* Which planet. */
-      m = p [p_i++] - 1 //*p++ - 1;
+      var m = p[p_i++] - 1 // *p++ - 1;
       if (j) {
-        /* k = abs (j); */
-        if (j < 0)
-          k = -j
-        else
-          k = j
+        /* var k = abs (j); */
+        var k = j < 0 ? -j : j
         k -= 1
-        su = this.ss[m][k]
+        var su = this.ss[m][k]
         /* sin(k*angle) */
         if (j < 0)
           su = -su
-        cu = this.cc[m][k]
+        var cu = this.cc[m][k]
         if (k1 == 0) { /* set first angle */
           sv = su
           cv = cu
           k1 = 1
         }
         else { /* combine angles */
-          t = su * cv + cu * sv
+          var tmp = su * cv + cu * sv
           cv = cu * cv - su * sv
-          sv = t
+          sv = tmp
         }
       }
     }
-    /* Highest power of T.  */
-    nt = p [p_i++] //*p++;
-    /* Cosine and sine coefficients.  */
-    cu = pl [pl_i++] //*pl++;
-    su = pl [pl_i++] //*pl++;
-    for (ip = 0; ip < nt; ip++) {
-      cu = cu * T + pl [pl_i++] //*pl++;
-      su = su * T + pl [pl_i++] //*pl++;
+    /* Highest power of T. */
+    var nt = p[p_i++] // *p++;
+    /* Cosine and sine coefficients. */
+    var cu = pl[pl_i++] // *pl++;
+    var su = pl[pl_i++] // *pl++;
+    for (var ip = 0; ip < nt; ip++) {
+      cu = cu * T + pl[pl_i++] // *pl++;
+      su = su * T + pl[pl_i++] // *pl++;
     }
     sl += cu * cv + su * sv
   }
   return body_ptable.trunclvl * sl
 }
 
-/* Compute geocentric moon.  */
+/* Compute geocentric moon. */
 $ns.gplan.moon = function (date, rect, pol) {
-  var x, cosB, sinB, cosL, sinL // double
-
   this.calc2(date, $moshier.plan404.moonlr, pol)
-  x = pol[0]
+  var x = pol[0]
   x += this.LP_equinox
   if (x < -6.48e5) {
     x += 1.296e6
@@ -711,12 +662,12 @@ $ns.gplan.moon = function (date, rect, pol) {
   pol[1] = $const.STR * x
   x = (1.0 + $const.STR * pol[2]) * $moshier.plan404.moonlr.distance
   pol[2] = x
-  /* Convert ecliptic polar to equatorial rectangular coordinates.  */
+  /* Convert ecliptic polar to equatorial rectangular coordinates. */
   $moshier.epsilon.calc(date)
-  cosB = Math.cos(pol[1])
-  sinB = Math.sin(pol[1])
-  cosL = Math.cos(pol[0])
-  sinL = Math.sin(pol[0])
+  var cosB = Math.cos(pol[1])
+  var sinB = Math.sin(pol[1])
+  var cosL = Math.cos(pol[0])
+  var sinL = Math.sin(pol[0])
   rect[0] = cosB * cosL * x
   rect[1] = ($moshier.epsilon.coseps * cosB * sinL - $moshier.epsilon.sineps * sinB) * x
   rect[2] = ($moshier.epsilon.sineps * cosB * sinL + $moshier.epsilon.coseps * sinB) * x

--- a/src/astronomy/moshier/gplan.js
+++ b/src/astronomy/moshier/gplan.js
@@ -98,7 +98,7 @@ $ns.gplan.calc = function (date, body_ptable, polar) {
       sr += cu
       continue
     }
-    var k1 = 0
+    var k1 = false
     var cv = 0.0
     var sv = 0.0
     for (var ip = 0; ip < np; ip++) {
@@ -114,10 +114,10 @@ $ns.gplan.calc = function (date, body_ptable, polar) {
         if (j < 0)
           su = -su
         var cu = this.cc[m][k]
-        if (k1 == 0) { /* set first angle */
+        if (!k1) { /* set first angle */
           sv = su
           cv = cu
-          k1 = 1
+          k1 = true
         }
         else { /* combine angles */
           var tmp = su * cv + cu * sv
@@ -171,7 +171,7 @@ $ns.gplan.sscc = function (k, arg, n) {
   /* sin(L) */
   this.cc[k][0] = cu
   /* cos(L) */
-  var sv = 2.0 * su * cu
+  var sv = 2 * su * cu
   var cv = cu * cu - su * su
   this.ss[k][1] = sv
   /* sin(2L) */
@@ -399,7 +399,7 @@ $ns.gplan.calc3 = function (date, body_ptable, polar, body_number) {
       sr += cu
       continue
     }
-    var k1 = 0
+    var k1 = false
     var cv = 0.0
     var sv = 0.0
     for (var ip = 0; ip < np; ip++) {
@@ -416,10 +416,10 @@ $ns.gplan.calc3 = function (date, body_ptable, polar, body_number) {
         if (j < 0)
           su = -su
         var cu = this.cc[m][k]
-        if (k1 == 0) { /* set first angle */
+        if (!k1) { /* set first angle */
           sv = su
           cv = cu
-          k1 = 1
+          k1 = true
         }
         else { /* combine angles */
           var tmp = su * cv + cu * sv
@@ -458,7 +458,7 @@ $ns.gplan.calc3 = function (date, body_ptable, polar, body_number) {
   var t = body_ptable.trunclvl
   polar[0] = this.Args[body_number - 1] + $const.STR * t * sl
   polar[1] = $const.STR * t * sb
-  polar[2] = body_ptable.distance * (1.0 + $const.STR * t * sr)
+  polar[2] = body_ptable.distance * (1 + $const.STR * t * sr)
 }
 
 /* Generic program to accumulate sum of trigonometric series
@@ -512,7 +512,7 @@ $ns.gplan.calc2 = function (date, body_ptable, polar) {
       sr += cu
       continue
     }
-    var k1 = 0
+    var k1 = false
     var cv = 0.0
     var sv = 0.0
     for (var ip = 0; ip < np; ip++) {
@@ -529,10 +529,10 @@ $ns.gplan.calc2 = function (date, body_ptable, polar) {
         if (j < 0)
           su = -su
         var cu = this.cc[m][k]
-        if (k1 == 0) { /* set first angle */
+        if (!k1) { /* set first angle */
           sv = su
           cv = cu
-          k1 = 1
+          k1 = true
         }
         else { /* combine angles */
           var tmp = su * cv + cu * sv
@@ -603,7 +603,7 @@ $ns.gplan.calc1 = function (date, body_ptable) {
       sl += cu
       continue
     }
-    var k1 = 0
+    var k1 = false
     var cv = 0.0
     var sv = 0.0
     for (var ip = 0; ip < np; ip++) {
@@ -620,10 +620,10 @@ $ns.gplan.calc1 = function (date, body_ptable) {
         if (j < 0)
           su = -su
         var cu = this.cc[m][k]
-        if (k1 == 0) { /* set first angle */
+        if (!k1) { /* set first angle */
           sv = su
           cv = cu
-          k1 = 1
+          k1 = true
         }
         else { /* combine angles */
           var tmp = su * cv + cu * sv
@@ -660,7 +660,7 @@ $ns.gplan.moon = function (date, rect, pol) {
   pol[0] = $const.STR * x
   x = this.calc1(date, $moshier.plan404.moonlat)
   pol[1] = $const.STR * x
-  x = (1.0 + $const.STR * pol[2]) * $moshier.plan404.moonlr.distance
+  x = (1 + $const.STR * pol[2]) * $moshier.plan404.moonlr.distance
   pol[2] = x
   /* Convert ecliptic polar to equatorial rectangular coordinates. */
   $moshier.epsilon.calc(date)

--- a/src/astronomy/moshier/julian.js
+++ b/src/astronomy/moshier/julian.js
@@ -49,13 +49,13 @@ $ns.julian.calc = function (date) {
   date.julianDate = b + c + e + date.day - 32167.5
 
   // Add time
-  date.julianTime = (3600.0 * date.hours + 60.0 * date.minutes + date.seconds) / 86400.0
+  date.julianTime = (3600 * date.hours + 60 * date.minutes + date.seconds) / 86400
 
   date.julian = date.julianDate + date.julianTime
 
-  date.j2000 = 2000.0 + (date.julian - $const.j2000) / 365.25
-  date.b1950 = 1950.0 + (date.julian - $const.b1950) / 365.25
-  date.j1900 = 1900.0 + (date.julian - $const.j1900) / 365.25
+  date.j2000 = 2000 + (date.julian - $const.j2000) / 365.25
+  date.b1950 = 1950 + (date.julian - $const.b1950) / 365.25
+  date.j1900 = 1900 + (date.julian - $const.j1900) / 365.25
 
   return date.julian
 }
@@ -124,7 +124,7 @@ $ns.julian.toGregorian = function (date) {
    */
   a = Math.floor(dd)
   dd = dd - a
-  x = 2.0 * Math.PI * dd
+  x = 2 * Math.PI * dd
 
   $copy(date, $util.hms(x))
 

--- a/src/astronomy/moshier/julian.js
+++ b/src/astronomy/moshier/julian.js
@@ -1,17 +1,12 @@
 $ns.julian = {}
 
 $ns.julian.calc = function (date) {
-  var centuries
-  var year
-  var month
   var b = 0
-  var c
-  var e
 
   /* The origin should be chosen to be a century year
    * that is also a leap year.  We pick 4801 B.C.
    */
-  year = date.year + 4800
+  var year = date.year + 4800
   if (date.year < 0) {
     year += 1
   }
@@ -21,15 +16,15 @@ $ns.julian.calc = function (date) {
    * days per calendar month.  It starts at 122 = March; January
    * and February come after December.
    */
-  month = date.month
+  var month = date.month
   if (month <= 2) {
     month += 12
     year -= 1
   }
-  e = Math.floor((306 * (month + 1)) / 10)
+  var e = Math.floor((306 * (month + 1)) / 10)
 
   // number of centuries
-  centuries = Math.floor(year / 100)
+  var centuries = Math.floor(year / 100)
 
   if (date.year <= 1582) {
     if (date.year == 1582) {
@@ -46,7 +41,7 @@ $ns.julian.calc = function (date) {
   }
 
   // Julian calendar years and leap years
-  c = Math.floor((36525 * year) / 100)
+  var c = Math.floor((36525 * year) / 100)
 
   /* Add up these terms, plus offset from J 0 to 1 Jan 4801 B.C.
    * Also fudge for the 122 days from the month algorithm.
@@ -66,26 +61,18 @@ $ns.julian.calc = function (date) {
 }
 
 $ns.julian.toGregorian = function (date) {
-  var month, day // int
-  var year, a, c, d, x, y, jd // int
-  var BC // int
-  var dd // double
   var J = date.julian
 
   /* January 1.0, 1 A.D. */
-  if (J < 1721423.5) {
-    BC = 1
-  } else {
-    BC = 0
-  }
+  var BC = J < 1721423.5 ? 1 : 0
 
-  jd = Math.floor(J + 0.5)
+  var jd = Math.floor(J + 0.5)
   /* round Julian date up to integer */
 
   /* Find the number of Gregorian centuries
    * since March 1, 4801 B.C.
    */
-  a = Math.floor((100 * jd + 3204500) / 3652425)
+  var a = Math.floor((100 * jd + 3204500) / 3652425)
 
   /* Transform to Julian calendar by adding in Gregorian century years
    * that are not leap years.
@@ -93,7 +80,7 @@ $ns.julian.toGregorian = function (date) {
    * Add 122 days for magic arithmetic algorithm.
    * Add four years to ensure the first leap year is detected.
    */
-  c = jd + 1486
+  var c = jd + 1486
   if (jd >= 2299160.5) {
     c += a - Math.floor(a / 4)
   } else {
@@ -102,26 +89,26 @@ $ns.julian.toGregorian = function (date) {
   /* Offset 122 days, which is where the magic arithmetic
    * month formula sequence starts (March 1 = 4 * 30.6 = 122.4).
    */
-  d = Math.floor((100 * c - 12210) / 36525)
+  var d = Math.floor((100 * c - 12210) / 36525)
   /* Days in that many whole Julian years */
-  x = Math.floor((36525 * d) / 100)
+  var x = Math.floor((36525 * d) / 100)
 
   /* Find month and day. */
-  y = Math.floor(((c - x) * 100) / 3061)
-  day = Math.floor(c - x - Math.floor((306 * y) / 10))
-  month = Math.floor(y - 1)
+  var y = Math.floor(((c - x) * 100) / 3061)
+  var day = Math.floor(c - x - Math.floor((306 * y) / 10))
+  var month = Math.floor(y - 1)
   if (y > 13) {
     month -= 12
   }
 
   /* Get the year right. */
-  year = d - 4715
+  var year = d - 4715
   if (month > 2) {
     year -= 1
   }
 
   /* Fractional part of day. */
-  dd = day + J - jd + 0.5
+  var dd = day + J - jd + 0.5
 
   if (BC) {
     year = year - 1

--- a/src/astronomy/moshier/julian.js
+++ b/src/astronomy/moshier/julian.js
@@ -122,8 +122,7 @@ $ns.julian.toGregorian = function (date) {
   /* Display fraction of calendar day
    * as clock time.
    */
-  a = Math.floor(dd)
-  dd = dd - a
+  dd = dd - Math.floor(dd)
   x = 2 * Math.PI * dd
 
   $copy(date, $util.hms(x))

--- a/src/astronomy/moshier/kepler.js
+++ b/src/astronomy/moshier/kepler.js
@@ -1,55 +1,51 @@
 $ns.kepler = {}
 
 $ns.kepler.calc = function (date, body, rect, polar) {
-  var alat, E, M, W, temp // double
-  var epoch, inclination, ascnode, argperih // double
-  var meandistance, dailymotion, eccent, meananomaly // double
-  var r, coso, sino, cosa // double
+  var alat // double
 
   rect = rect || []
   polar = polar || []
 
-  /* Call program to compute position, if one is supplied.  */
+  /* Call program to compute position, if one is supplied. */
   if (body.ptable) {
     if (body.key == 'earth') {
       $moshier.gplan.calc3(date, body.ptable, polar, 3)
     } else {
       $moshier.gplan.calc(date, body.ptable, polar)
     }
-    E = polar[0]
+    var E = polar[0]
     /* longitude */
     body.longitude = E
-    W = polar[1]
+    var W = polar[1]
     /* latitude */
-    r = polar[2]
+    var r = polar[2]
     /* radius */
     body.distance = r
     body.epoch = date.julian
     body.equinox = {julian: $const.j2000}
     // goto kepdon;
   } else {
-    /* Decant the parameters from the data structure
-     */
-    epoch = body.epoch
-    inclination = body.inclination
-    ascnode = body.node * $const.DTR
-    argperih = body.perihelion
-    meandistance = body.semiAxis
+    /* Decant the parameters from the data structure */
+    var epoch = body.epoch
+    var inclination = body.inclination
+    var ascnode = body.node * $const.DTR
+    var argperih = body.perihelion
+    var meandistance = body.semiAxis
     /* semimajor axis */
-    dailymotion = body.dailyMotion
-    eccent = body.eccentricity
-    meananomaly = body.anomaly
+    var dailymotion = body.dailyMotion
+    var eccent = body.eccentricity
+    var meananomaly = body.anomaly
     /* Check for parabolic orbit. */
     if (eccent == 1.0) {
       /* meandistance = perihelion distance, q
        * epoch = perihelion passage date
        */
-      temp = meandistance * Math.sqrt(meandistance)
+      var temp = meandistance * Math.sqrt(meandistance)
       W = (date.julian - epoch) * 0.0364911624 / temp
       /* The constant above is 3 k / sqrt(2),
-       * k = Gaussian gravitational constant = 0.01720209895 . */
+       * k = Gaussian gravitational constant = 0.01720209895 */
       E = 0.0
-      M = 1.0
+      var M = 1.0
       while (Math.abs(M) > 1.0e-11) {
         temp = E * E
         temp = (2.0 * E * temp + W) / (3.0 * (1.0 + temp))
@@ -88,8 +84,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
         alat = M + $const.DTR * argperih
         // goto parabcon;
       } else {
-        /* Calculate the daily motion, if it is not given.
-         */
+        /* Calculate the daily motion, if it is not given. */
         if (dailymotion == 0.0) {
           /* The constant is 180 k / pi, k = Gaussian gravitational constant.
            * Assumes object in heliocentric orbit is massless.
@@ -153,8 +148,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
         temp = Math.sqrt((1.0 + eccent) / (1.0 - eccent))
         W = 2.0 * Math.atan(temp * Math.tan(0.5 * E))
 
-        /* The true anomaly.
-         */
+        /* The true anomaly. */
         W = $util.modtp(W)
 
         meananomaly *= $const.DTR
@@ -179,8 +173,8 @@ $ns.kepler.calc = function (date, body, rect, polar) {
      * is given by
      *   tan( longitude - ascnode )  =  cos( inclination ) * tan( alat ).
      */
-    coso = Math.cos(alat)
-    sino = Math.sin(alat)
+    var coso = Math.cos(alat)
+    var sino = Math.sin(alat)
     inclination *= $const.DTR
     W = sino * Math.cos(inclination)
     E = $util.zatan2(coso, W) + ascnode
@@ -196,7 +190,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
    * using the perturbed latitude.
    */
   rect[2] = r * Math.sin(W)
-  cosa = Math.cos(W)
+  var cosa = Math.cos(W)
   rect[1] = r * cosa * Math.sin(E)
   rect[0] = r * cosa * Math.cos(E)
 
@@ -233,8 +227,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
   E = $util.zatan2(rect[0], W)
   W = Math.asin(M / r)
 
-  /* Output the polar cooordinates
-   */
+  /* Output the polar cooordinates */
   polar[0] = E
   /* longitude */
   polar[1] = W
@@ -261,10 +254,8 @@ $ns.kepler.calc = function (date, body, rect, polar) {
  */
 $ns.kepler.embofs = function (date, ea) {
   var pm = [], polm = [] // double
-  var a, b // double
-  var i // int
 
-  /* Compute the vector Moon - Earth.  */
+  /* Compute the vector Moon - Earth. */
   $moshier.gplan.moon(date, pm, polm)
 
   /* Precess the lunar position
@@ -272,34 +263,31 @@ $ns.kepler.embofs = function (date, ea) {
    */
   $moshier.precess.calc(pm, date, 1)
 
-  /* Adjust the coordinates of the Earth
-   */
-  a = 1.0 / ($const.emrat + 1.0)
-  b = 0.0
-  for (i = 0; i < 3; i++) {
+  /* Adjust the coordinates of the Earth */
+  var a = 1.0 / ($const.emrat + 1.0)
+  var b = 0.0
+  for (var i = 0; i < 3; i++) {
     ea[i] = ea[i] - a * pm[i]
     b = b + ea[i] * ea[i]
   }
-  /* Sun-Earth distance.  */
+  /* Sun-Earth distance. */
   return Math.sqrt(b)
 }
 
 $ns.kepler.init = function () {
-  var a, b, fl, co, si, u // double
-
-  u = $const.glat * $const.DTR
+  var u = $const.glat * $const.DTR
 
   /* Reduction from geodetic latitude to geocentric latitude
    * AA page K5
    */
-  co = Math.cos(u)
-  si = Math.sin(u)
-  fl = 1.0 - 1.0 / $const.flat
+  var co = Math.cos(u)
+  var si = Math.sin(u)
+  var fl = 1.0 - 1.0 / $const.flat
   fl = fl * fl
   si = si * si
   u = 1.0 / Math.sqrt(co * co + fl * si)
-  a = $const.aearth * u + $const.height
-  b = $const.aearth * fl * u + $const.height
+  var a = $const.aearth * u + $const.height
+  var b = $const.aearth * fl * u + $const.height
   $const.trho = Math.sqrt(a * a * co * co + b * b * si)
   $const.tlat = $const.RTD * Math.acos(a * co / $const.trho)
   if ($const.glat < 0.0) {

--- a/src/astronomy/moshier/kepler.js
+++ b/src/astronomy/moshier/kepler.js
@@ -1,9 +1,8 @@
 $ns.kepler = {}
 
 $ns.kepler.calc = function (date, body, rect, polar) {
-  var alat // double
+  var alat, E, M, W, r // double
 
-  rect = rect || []
   polar = polar || []
 
   /* Call program to compute position, if one is supplied. */
@@ -13,12 +12,12 @@ $ns.kepler.calc = function (date, body, rect, polar) {
     } else {
       $moshier.gplan.calc(date, body.ptable, polar)
     }
-    var E = polar[0]
+    E = polar[0]
     /* longitude */
     body.longitude = E
-    var W = polar[1]
+    W = polar[1]
     /* latitude */
-    var r = polar[2]
+    r = polar[2]
     /* radius */
     body.distance = r
     body.epoch = date.julian
@@ -45,42 +44,42 @@ $ns.kepler.calc = function (date, body, rect, polar) {
       /* The constant above is 3 k / sqrt(2),
        * k = Gaussian gravitational constant = 0.01720209895 */
       E = 0.0
-      var M = 1.0
+      M = 1.0
       while (Math.abs(M) > 1.0e-11) {
         temp = E * E
-        temp = (2.0 * E * temp + W) / (3.0 * (1.0 + temp))
+        temp = (2 * E * temp + W) / (3 * (1 + temp))
         M = temp - E
         if (temp != 0.0) {
           M /= temp
         }
         E = temp
       }
-      r = meandistance * (1.0 + E * E)
+      r = meandistance * (1 + E * E)
       M = Math.atan(E)
-      M = 2.0 * M
+      M = 2 * M
       alat = M + $const.DTR * argperih
       // goto parabcon;
     } else {
-      if (eccent > 1.0) {
+      if (eccent > 1) {
         /* The equation of the hyperbola in polar coordinates r, theta
          * is r = a(e^2 - 1)/(1 + e cos(theta))
          * so the perihelion distance q = a(e-1),
          * the "mean distance"  a = q/(e-1).
          */
-        meandistance = meandistance / (eccent - 1.0)
-        temp = meandistance * Math.sqrt(meandistance)
+        meandistance = meandistance / (eccent - 1)
+        var temp = meandistance * Math.sqrt(meandistance)
         W = (date.julian - epoch) * 0.01720209895 / temp
         /* solve M = -E + e sinh E */
-        E = W / (eccent - 1.0)
+        E = W / (eccent - 1)
         M = 1.0
         while (Math.abs(M) > 1.0e-11) {
           M = -E + eccent * $util.sinh(E) - W
-          E += M / (1.0 - eccent * $util.cosh(E))
+          E += M / (1 - eccent * $util.cosh(E))
         }
-        r = meandistance * (-1.0 + eccent * $util.cosh(E))
-        temp = (eccent + 1.0) / (eccent - 1.0)
+        r = meandistance * (-1 + eccent * $util.cosh(E))
+        temp = (eccent + 1) / (eccent - 1)
         M = Math.sqrt(temp) * $util.tanh(0.5 * E)
-        M = 2.0 * Math.atan(M)
+        M = 2 * Math.atan(M)
         alat = M + $const.DTR * argperih
         // goto parabcon;
       } else {
@@ -125,7 +124,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
 
         E = M
         /* Initial guess is same as circular orbit. */
-        temp = 1.0
+        var temp = 1.0
         do {
           /* The approximate area swept out in the ellipse */
           temp = E - eccent * Math.sin(E)
@@ -134,7 +133,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
           /* ...should be zero.  Use the derivative of the error
            * to converge to solution by Newton's method.
            */
-          E -= temp / (1.0 - eccent * Math.cos(E))
+          E -= temp / (1 - eccent * Math.cos(E))
         } while (Math.abs(temp) > 1.0e-11)
 
         /* The exact formula for the area in the ellipse is
@@ -145,8 +144,8 @@ $ns.kepler.calc = function (date, body, rect, polar) {
          * Substituting the following value of W
          * yields the exact solution.
          */
-        temp = Math.sqrt((1.0 + eccent) / (1.0 - eccent))
-        W = 2.0 * Math.atan(temp * Math.tan(0.5 * E))
+        temp = Math.sqrt((1 + eccent) / (1 - eccent))
+        W = 2 * Math.atan(temp * Math.tan(0.5 * E))
 
         /* The true anomaly. */
         W = $util.modtp(W)
@@ -156,7 +155,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
          * (argument of latitude)
          */
         if (body.longitude) {
-          alat = (body.longitude) * $const.DTR + W - meananomaly - ascnode
+          alat = body.longitude * $const.DTR + W - meananomaly - ascnode
         } else {
           alat = W + $const.DTR * argperih
           /* mean longitude not given */
@@ -165,13 +164,13 @@ $ns.kepler.calc = function (date, body, rect, polar) {
         /* From the equation of the ellipse, get the
          * radius from central focus to the object.
          */
-        r = meandistance * (1.0 - eccent * eccent) / (1.0 + eccent * Math.cos(W))
+        r = meandistance * (1 - eccent * eccent) / (1 + eccent * Math.cos(W))
       }
     }
 // parabcon:
     /* The heliocentric ecliptic longitude of the object
      * is given by
-     *   tan( longitude - ascnode )  =  cos( inclination ) * tan( alat ).
+     *   tan(longitude - ascnode) = cos(inclination) * tan(alat)
      */
     var coso = Math.cos(alat)
     var sino = Math.sin(alat)
@@ -179,8 +178,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
     W = sino * Math.cos(inclination)
     E = $util.zatan2(coso, W) + ascnode
 
-    /* The ecliptic latitude of the object
-     */
+    /* The ecliptic latitude of the object */
     W = sino * Math.sin(inclination)
     W = Math.asin(W)
   }
@@ -189,6 +187,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
   /* Convert to rectangular coordinates,
    * using the perturbed latitude.
    */
+  rect = rect || []
   rect[2] = r * Math.sin(W)
   var cosa = Math.cos(W)
   rect[1] = r * cosa * Math.sin(E)
@@ -218,7 +217,7 @@ $ns.kepler.calc = function (date, body, rect, polar) {
     /* see below */
   }
 
-  /* Rotate back into the ecliptic.  */
+  /* Rotate back into the ecliptic. */
   $moshier.epsilon.calc({julian: $const.j2000})
   W = $moshier.epsilon.coseps * rect[1] + $moshier.epsilon.sineps * rect[2]
   M = -$moshier.epsilon.sineps * rect[1] + $moshier.epsilon.coseps * rect[2]
@@ -264,7 +263,7 @@ $ns.kepler.embofs = function (date, ea) {
   $moshier.precess.calc(pm, date, 1)
 
   /* Adjust the coordinates of the Earth */
-  var a = 1.0 / ($const.emrat + 1.0)
+  var a = 1 / ($const.emrat + 1)
   var b = 0.0
   for (var i = 0; i < 3; i++) {
     ea[i] = ea[i] - a * pm[i]
@@ -282,15 +281,15 @@ $ns.kepler.init = function () {
    */
   var co = Math.cos(u)
   var si = Math.sin(u)
-  var fl = 1.0 - 1.0 / $const.flat
+  var fl = 1 - 1 / $const.flat
   fl = fl * fl
   si = si * si
-  u = 1.0 / Math.sqrt(co * co + fl * si)
+  u = 1 / Math.sqrt(co * co + fl * si)
   var a = $const.aearth * u + $const.height
   var b = $const.aearth * fl * u + $const.height
   $const.trho = Math.sqrt(a * a * co * co + b * b * si)
   $const.tlat = $const.RTD * Math.acos(a * co / $const.trho)
-  if ($const.glat < 0.0) {
+  if ($const.glat < 0) {
     $const.tlat = -$const.tlat
   }
   $const.trho /= $const.aearth
@@ -304,16 +303,16 @@ $ns.kepler.init = function () {
    + 0.00032314 * sin(4.0*u)
    - 0.00000072 * sin(6.0*u);
 
-   trho =    0.998327073
+   trho = 0.998327073
    + 0.001676438 * cos(2.0*u)
    - 0.000003519 * cos(4.0*u)
    + 0.000000008 * cos(6.0*u);
    trho += height/6378160.;
    */
 
-  $const.Clightaud = 86400.0 * $const.Clight / $const.au
+  $const.Clightaud = 86400 * $const.Clight / $const.au
   /* Radius of the earth in au
    Thanks to Min He <Min.He@businessobjects.com> for pointing out
-   this needs to be initialized early.  */
+   this needs to be initialized early. */
   $const.Rearth = 0.001 * $const.aearth / $const.au
 }

--- a/src/astronomy/moshier/kepler.js
+++ b/src/astronomy/moshier/kepler.js
@@ -12,13 +12,12 @@ $ns.kepler.calc = function (date, body, rect, polar) {
     } else {
       $moshier.gplan.calc(date, body.ptable, polar)
     }
-    E = polar[0]
     /* longitude */
-    body.longitude = E
-    W = polar[1]
+    body.longitude = E = polar[0]
     /* latitude */
-    r = polar[2]
+    W = polar[1]
     /* radius */
+    r = polar[2]
     body.distance = r
     body.epoch = date.julian
     body.equinox = {julian: $const.j2000}
@@ -29,8 +28,8 @@ $ns.kepler.calc = function (date, body, rect, polar) {
     var inclination = body.inclination
     var ascnode = body.node * $const.DTR
     var argperih = body.perihelion
-    var meandistance = body.semiAxis
     /* semimajor axis */
+    var meandistance = body.semiAxis
     var dailymotion = body.dailyMotion
     var eccent = body.eccentricity
     var meananomaly = body.anomaly
@@ -227,12 +226,12 @@ $ns.kepler.calc = function (date, body, rect, polar) {
   W = Math.asin(M / r)
 
   /* Output the polar cooordinates */
-  polar[0] = E
   /* longitude */
-  polar[1] = W
+  polar[0] = E
   /* latitude */
-  polar[2] = r
+  polar[1] = W
   /* radius */
+  polar[2] = r
 
   // fill the body.position only if rect and polar are
   // not defined
@@ -307,7 +306,7 @@ $ns.kepler.init = function () {
    + 0.001676438 * cos(2.0*u)
    - 0.000003519 * cos(4.0*u)
    + 0.000000008 * cos(6.0*u);
-   trho += height/6378160.;
+   trho += height/6378160;
    */
 
   $const.Clightaud = 86400 * $const.Clight / $const.au

--- a/src/astronomy/moshier/light.js
+++ b/src/astronomy/moshier/light.js
@@ -1,8 +1,7 @@
 $ns.light = {}
 
 $ns.light.calc = function (body, q, e) {
-  var p = [], p0 = [], ptemp = [] // double
-  var t // double
+  var p = [], p0 = [], t // double
 
   /* save initial q-e vector for display */
   for (var i = 0; i < 3; i++) {
@@ -19,26 +18,23 @@ $ns.light.calc = function (body, q, e) {
     var P = 0.0
     var Q = 0.0
     for (var i = 0; i < 3; i++) {
-      var y = q[i]
-      var x = y - e[i]
-      p[i] = x
-      Q += y * y
-      P += x * x
+      p[i] = q[i] - e[i]
+      Q += q[i] * q[i]
+      P += p[i] * p[i]
     }
     P = Math.sqrt(P)
     Q = Math.sqrt(Q)
     /* Note the following blows up if object equals sun. */
     t = (P + 1.97e-8 * Math.log((E + P + Q) / (E - P + Q))) / 173.1446327
-    $moshier.kepler.calc({julian: $moshier.body.earth.position.date.julian - t}, body, q, ptemp)
+    $moshier.kepler.calc({julian: $moshier.body.earth.position.date.julian - t}, body, q, [])
   }
 
-  body.lightTime = 1440.0 * t
+  body.lightTime = 1440 * t
 
   /* Final object-earth vector and the amount by which it changed. */
   for (var i = 0; i < 3; i++) {
-    var x = q[i] - e[i]
-    p[i] = x
-    $const.dp[i] = x - p0[i]
+    p[i] = q[i] - e[i]
+    $const.dp[i] = p[i] - p0[i]
   }
   body.aberration = $util.showcor(p0, $const.dp)
 
@@ -59,7 +55,7 @@ $ns.light.calc = function (body, q, e) {
   }
 
   var d = $util.deltap(p, p0)
-  /* see dms.c */
+  /* see $util.dms() */
   $const.dradt = d.dr
   $const.ddecdt = d.dd
   $const.dradt /= t

--- a/src/astronomy/moshier/light.js
+++ b/src/astronomy/moshier/light.js
@@ -2,26 +2,25 @@ $ns.light = {}
 
 $ns.light.calc = function (body, q, e) {
   var p = [], p0 = [], ptemp = [] // double
-  var P, Q, E, t, x, y // double
-  var i, k // int
+  var t // double
 
   /* save initial q-e vector for display */
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     p0[i] = q[i] - e[i]
   }
 
-  E = 0.0
-  for (i = 0; i < 3; i++) {
+  var E = 0.0
+  for (var i = 0; i < 3; i++) {
     E += e[i] * e[i]
   }
   E = Math.sqrt(E)
 
-  for (k = 0; k < 2; k++) {
-    P = 0.0
-    Q = 0.0
-    for (i = 0; i < 3; i++) {
-      y = q[i]
-      x = y - e[i]
+  for (var k = 0; k < 2; k++) {
+    var P = 0.0
+    var Q = 0.0
+    for (var i = 0; i < 3; i++) {
+      var y = q[i]
+      var x = y - e[i]
       p[i] = x
       Q += y * y
       P += x * x
@@ -35,12 +34,11 @@ $ns.light.calc = function (body, q, e) {
 
   body.lightTime = 1440.0 * t
 
-  /* Final object-earth vector and the amount by which it changed.
-   */
-  for (i = 0; i < 3; i++) {
-    x = q[i] - e[i]
+  /* Final object-earth vector and the amount by which it changed. */
+  for (var i = 0; i < 3; i++) {
+    var x = q[i] - e[i]
     p[i] = x
-    $const.dp [i] = x - p0[i]
+    $const.dp[i] = x - p0[i]
   }
   body.aberration = $util.showcor(p0, $const.dp)
 
@@ -56,8 +54,8 @@ $ns.light.calc = function (body, q, e) {
    */
   $moshier.vearth.calc($moshier.body.earth.position.date)
 
-  for (i = 0; i < 3; i++) {
-    p[i] += $moshier.vearth.vearth [i] * t
+  for (var i = 0; i < 3; i++) {
+    p[i] += $moshier.vearth.vearth[i] * t
   }
 
   var d = $util.deltap(p, p0)

--- a/src/astronomy/moshier/lonlat.js
+++ b/src/astronomy/moshier/lonlat.js
@@ -26,14 +26,10 @@ $ns.lonlat.calc = function (pp, date, ofdate) {
   var yy = $util.zatan2(s[0], y)
   var zz = Math.asin(z / r)
 
-  var result = {}
-  // longitude and latitude in decimal
-  result[0] = yy
-  result[1] = zz
-  result[2] = r
-  // longitude and latitude in h,m,s
-  result[3] = $util.dms(yy)
-  result[4] = $util.dms(zz)
-
-  return result
+  return [
+    // longitude and latitude in decimal
+    yy, zz, r,
+    // longitude and latitude in h,m,s
+    $util.dms(yy), $util.dms(zz)
+  ]
 }

--- a/src/astronomy/moshier/lonlat.js
+++ b/src/astronomy/moshier/lonlat.js
@@ -1,54 +1,43 @@
 $ns.lonlat = {}
 
-$ns.lonlat.calc = function (pp, date, polar, ofdate, result) {
-  var s = [], x, y, z, yy, zz, r // double
-  var i // int
-
-  result = result || {}
+$ns.lonlat.calc = function (pp, date, ofdate) {
+  var s = [] // double
 
   /* Make local copy of position vector
    * and calculate radius.
    */
-  r = 0.0
-  for (i = 0; i < 3; i++) {
-    x = pp [i]
-    s [i] = x
+  var r = 0.0
+  for (var i = 0; i < 3; i++) {
+    var x = pp[i]
+    s[i] = x
     r += x * x
   }
   r = Math.sqrt(r)
 
-  /* Precess to equinox of date J
-   */
+  /* Precess to equinox of date J */
   if (ofdate) {
     $moshier.precess.calc(s, date, -1)
   }
 
-  /* Convert from equatorial to ecliptic coordinates
-   */
+  /* Convert from equatorial to ecliptic coordinates */
   $moshier.epsilon.calc(date)
-  yy = s[1]
-  zz = s[2]
-  x = s[0]
-  y = $moshier.epsilon.coseps * yy + $moshier.epsilon.sineps * zz
-  z = -$moshier.epsilon.sineps * yy + $moshier.epsilon.coseps * zz
+  var yy = s[1]
+  var zz = s[2]
+  var x = s[0]
+  var y = $moshier.epsilon.coseps * yy + $moshier.epsilon.sineps * zz
+  var z = -$moshier.epsilon.sineps * yy + $moshier.epsilon.coseps * zz
 
   yy = $util.zatan2(x, y)
   zz = Math.asin(z / r)
 
+  var result = {}
   // longitude and latitude in decimal
-  polar[0] = yy
-  polar[1] = zz
-  polar[2] = r
-
+  result[0] = yy
+  result[1] = zz
+  result[2] = r
   // longitude and latitude in h,m,s
-  polar [3] = $util.dms(polar[0])
-  polar [4] = $util.dms(polar[1])
-
-  result [0] = polar [0]
-  result [1] = polar [1]
-  result [2] = polar [2]
-  result [3] = polar [3]
-  result [4] = polar [4]
+  result[3] = $util.dms(yy)
+  result[4] = $util.dms(zz)
 
   return result
 }

--- a/src/astronomy/moshier/lonlat.js
+++ b/src/astronomy/moshier/lonlat.js
@@ -8,9 +8,8 @@ $ns.lonlat.calc = function (pp, date, ofdate) {
    */
   var r = 0.0
   for (var i = 0; i < 3; i++) {
-    var x = pp[i]
-    s[i] = x
-    r += x * x
+    s[i] = pp[i]
+    r += pp[i] * pp[i]
   }
   r = Math.sqrt(r)
 
@@ -21,14 +20,11 @@ $ns.lonlat.calc = function (pp, date, ofdate) {
 
   /* Convert from equatorial to ecliptic coordinates */
   $moshier.epsilon.calc(date)
-  var yy = s[1]
-  var zz = s[2]
-  var x = s[0]
-  var y = $moshier.epsilon.coseps * yy + $moshier.epsilon.sineps * zz
-  var z = -$moshier.epsilon.sineps * yy + $moshier.epsilon.coseps * zz
+  var y = $moshier.epsilon.coseps * s[1] + $moshier.epsilon.sineps * s[2]
+  var z = -$moshier.epsilon.sineps * s[1] + $moshier.epsilon.coseps * s[2]
 
-  yy = $util.zatan2(x, y)
-  zz = Math.asin(z / r)
+  var yy = $util.zatan2(s[0], y)
+  var zz = Math.asin(z / r)
 
   var result = {}
   // longitude and latitude in decimal

--- a/src/astronomy/moshier/moon.js
+++ b/src/astronomy/moshier/moon.js
@@ -8,7 +8,7 @@ $ns.moon = {
  * phase of the Moon, etc. for AA.ARC.
  */
 $ns.moon.calc = function () {
-  var pp = [], qq = [], re = [], moonpp = [], moonpol = [] // double
+  var qq = [], re = [], moonpp = [], moonpol = [] // double
 
   $moshier.body.moon.position = {
     polar: [],
@@ -44,17 +44,19 @@ $ns.moon.calc = function () {
    * correct the time of rising, transit, and setting.
    */
   $const.dradt = this.ra - ra0
-  if ($const.dradt >= Math.PI)
-    $const.dradt = $const.dradt - 2.0 * Math.PI
-  if ($const.dradt <= -Math.PI)
-    $const.dradt = $const.dradt + 2.0 * Math.PI
-  $const.dradt = 1000.0 * $const.dradt
-  $const.ddecdt = 1000.0 * (this.dec - dec0)
+  if ($const.dradt >= Math.PI) {
+    $const.dradt = $const.dradt - 2 * Math.PI
+  }
+  if ($const.dradt <= -Math.PI) {
+    $const.dradt = $const.dradt + 2 * Math.PI
+  }
+  $const.dradt = 1000 * $const.dradt
+  $const.ddecdt = 1000 * (this.dec - dec0)
 
   /* Rate of change in longitude, degrees per day
    * used for phase of the moon
    */
-  lon0 = 1000.0 * $const.RTD * (moonpol[0] - lon0)
+  lon0 = 1000 * $const.RTD * (moonpol[0] - lon0)
 
   /* Get apparent coordinates for the earth. */
   var z = Math.sqrt(re[0] * re[0] + re[1] * re[1] + re[2] * re[2])
@@ -114,7 +116,7 @@ $ns.moon.calc = function () {
   x = $const.RTD * Math.acos(-$const.ep)
   /* x = 180.0 - RTD * arcdot (re, pp); */
   $moshier.body.moon.position.sunElongation = x
-  x = 0.5 * (1.0 + $const.pq)
+  x = 0.5 * (1 + $const.pq)
   $moshier.body.moon.position.illuminatedFraction = x
 
   /* Find phase of the Moon by comparing Moon's longitude
@@ -128,24 +130,22 @@ $ns.moon.calc = function () {
   x = moonpol[0] - pe[0]
   x = $util.modtp(x) * $const.RTD
   /* difference in longitude */
-  i = Math.floor(x / 90)
+  var y = Math.floor(x / 90)
   /* number of quarters */
-  x = (x - i * 90.0)
+  x = x - y * 90
   /* phase angle mod 90 degrees */
 
   /* days per degree of phase angle */
   z = moonpol[2] / (12.3685 * 0.00257357)
 
-  if (x > 45.0) {
-    var y = -(x - 90.0) * z
-    $moshier.body.moon.position.phaseDaysBefore = y
-    i = (i + 1) & 3
+  if (x > 45) {
+    $moshier.body.moon.position.phaseDaysBefore = -(x - 90) * z
+    y = (y + 1) & 3
   } else {
-    var y = x * z
-    $moshier.body.moon.position.phaseDaysPast = y
+    $moshier.body.moon.position.phaseDaysPast = x * z
   }
 
-  $moshier.body.moon.position.phaseQuarter = i
+  $moshier.body.moon.position.phaseQuarter = y
 
   $moshier.body.moon.position.apparent = {
     dRA: this.ra,
@@ -155,9 +155,7 @@ $ns.moon.calc = function () {
   }
 
   /* Compute and display topocentric position (altaz.js) */
-  pp[0] = this.ra
-  pp[1] = this.dec
-  pp[2] = moonpol[2]
+  var pp = [ this.ra, this.dec, moonpol[2] ]
   $moshier.body.moon.position.altaz = $moshier.altaz.calc(pp, $moshier.body.earth.position.date)
 }
 

--- a/src/astronomy/moshier/moon.js
+++ b/src/astronomy/moshier/moon.js
@@ -1,6 +1,6 @@
 $ns.moon = {
   ra: 0.0, /* Right Ascension */
-  dec: 0.0  /* Declination */
+  dec: 0.0 /* Declination */
 }
 
 /* Calculate geometric position of the Moon and apply
@@ -8,34 +8,29 @@ $ns.moon = {
  * phase of the Moon, etc. for AA.ARC.
  */
 $ns.moon.calc = function () {
-  var i, prtsav // int
-  var ra0, dec0 // double
-  var x, y, z, lon0 // double
-  var pp = [], qq = [], pe = [], re = [], moonpp = [], moonpol = [] // double
+  var pp = [], qq = [], re = [], moonpp = [], moonpol = [] // double
 
   $moshier.body.moon.position = {
     polar: [],
     rect: []
   }
 
-  /* Geometric equatorial coordinates of the earth.  */
-  for (i = 0; i < 3; i++) {
-    re [i] = $moshier.body.earth.position.rect [i]
+  /* Geometric equatorial coordinates of the earth. */
+  for (var i = 0; i < 3; i++) {
+    re[i] = $moshier.body.earth.position.rect[i]
   }
 
   /* Run the orbit calculation twice, at two different times,
    * in order to find the rate of change of R.A. and Dec.
    */
 
-  /* Calculate for 0.001 day ago
-   */
+  /* Calculate for 0.001 day ago */
   this.calcll({julian: $moshier.body.earth.position.date.julian - 0.001}, moonpp, moonpol) // TDT - 0.001
-  ra0 = this.ra
-  dec0 = this.dec
-  lon0 = moonpol[0]
+  var ra0 = this.ra
+  var dec0 = this.dec
+  var lon0 = moonpol[0]
 
-  /* Calculate for present instant.
-   */
+  /* Calculate for present instant. */
   $moshier.body.moon.position.nutation = this.calcll($moshier.body.earth.position.date, moonpp, moonpol).nutation
 
   $moshier.body.moon.position.geometric = {
@@ -61,10 +56,9 @@ $ns.moon.calc = function () {
    */
   lon0 = 1000.0 * $const.RTD * (moonpol[0] - lon0)
 
-  /* Get apparent coordinates for the earth.  */
-  z = re [0] * re [0] + re [1] * re [1] + re [2] * re [2]
-  z = Math.sqrt(z)
-  for (i = 0; i < 3; i++) {
+  /* Get apparent coordinates for the earth. */
+  var z = Math.sqrt(re[0] * re[0] + re[1] * re[1] + re[2] * re[2])
+  for (var i = 0; i < 3; i++) {
     re[i] /= z
   }
 
@@ -74,26 +68,25 @@ $ns.moon.calc = function () {
   /* pe[0] -= STR * (20.496/(RTS*pe[2])); */
   $moshier.precess.calc(re, $moshier.body.earth.position.date, -1)
   $moshier.nutation.calc($moshier.body.earth.position.date, re)
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     re[i] *= z
   }
 
-  $moshier.lonlat.calc(re, $moshier.body.earth.position.date, pe, 0)
+  var pe = $moshier.lonlat.calc(re, $moshier.body.earth.position.date, false)
 
   /* Find sun-moon-earth angles */
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     qq[i] = re[i] + moonpp[i]
   }
   $util.angles(moonpp, qq, re)
 
-  /* Display answers
-   */
+  /* Display answers */
   $moshier.body.moon.position.apparentGeocentric = {
-    longitude: moonpol [0],
-    dLongitude: $const.RTD * moonpol [0],
-    latitude: moonpol [1],
-    dLatitude: $const.RTD * moonpol [1],
-    distance: moonpol [2] / $const.Rearth
+    longitude: moonpol[0],
+    dLongitude: $const.RTD * moonpol[0],
+    latitude: moonpol[1],
+    dLatitude: $const.RTD * moonpol[1],
+    distance: moonpol[2] / $const.Rearth
   }
   $moshier.body.moon.position.apparentLongitude = $moshier.body.moon.position.apparentGeocentric.dLongitude
   var dmsLongitude = $util.dms($moshier.body.moon.position.apparentGeocentric.longitude)
@@ -107,9 +100,9 @@ $ns.moon.calc = function () {
     dmsLongitude.minutes + '\'' +
     Math.floor(dmsLongitude.seconds) + '"'
 
-  $moshier.body.moon.position.geocentricDistance = moonpol [2] / $const.Rearth
+  $moshier.body.moon.position.geocentricDistance = moonpol[2] / $const.Rearth
 
-  x = $const.Rearth / moonpol[2]
+  var x = $const.Rearth / moonpol[2]
   $moshier.body.moon.position.dHorizontalParallax = Math.asin(x)
   $moshier.body.moon.position.horizontalParallax = $util.dms(Math.asin(x))
 
@@ -144,11 +137,11 @@ $ns.moon.calc = function () {
   z = moonpol[2] / (12.3685 * 0.00257357)
 
   if (x > 45.0) {
-    y = -(x - 90.0) * z
+    var y = -(x - 90.0) * z
     $moshier.body.moon.position.phaseDaysBefore = y
     i = (i + 1) & 3
   } else {
-    y = x * z
+    var y = x * z
     $moshier.body.moon.position.phaseDaysPast = y
   }
 
@@ -171,12 +164,8 @@ $ns.moon.calc = function () {
 /* Calculate apparent latitude, longitude, and horizontal parallax
  * of the Moon at Julian date J.
  */
-$ns.moon.calcll = function (date, rect, pol, result) {
-  var cosB, sinB, cosL, sinL, y, z // double
+$ns.moon.calcll = function (date, rect, pol) {
   var qq = [], pp = [] // double
-  var i // int
-
-  result = result || {}
 
   /* Compute obliquity of the ecliptic, coseps, and sineps. */
   $moshier.epsilon.calc(date)
@@ -185,7 +174,7 @@ $ns.moon.calcll = function (date, rect, pol, result) {
   /* Post the geometric ecliptic longitude and latitude, in radians,
    * and the radius in au.
    */
-  $const.body.position.polar [0] = pol[0]
+  $const.body.position.polar[0] = pol[0]
   $const.body.position.polar[1] = pol[1]
   $const.body.position.polar[2] = pol[2]
 
@@ -195,10 +184,10 @@ $ns.moon.calcll = function (date, rect, pol, result) {
   pol[0] -= 0.0118 * $const.DTR * $const.Rearth / pol[2]
 
   /* convert to equatorial system of date */
-  cosB = Math.cos(pol[1])
-  sinB = Math.sin(pol[1])
-  cosL = Math.cos(pol[0])
-  sinL = Math.sin(pol[0])
+  var cosB = Math.cos(pol[1])
+  var sinB = Math.sin(pol[1])
+  var cosL = Math.cos(pol[0])
+  var sinL = Math.sin(pol[0])
   rect[0] = cosB * cosL
   rect[1] = $moshier.epsilon.coseps * cosB * sinL - $moshier.epsilon.sineps * sinB
   rect[2] = $moshier.epsilon.sineps * cosB * sinL + $moshier.epsilon.coseps * sinB
@@ -206,16 +195,15 @@ $ns.moon.calcll = function (date, rect, pol, result) {
   /* Rotate to J2000. */
   $moshier.precess.calc(rect, {julian: $moshier.body.earth.position.date.julian}, 1) // TDT
 
-  /* Find Euclidean vectors and angles between earth, object, and the sun
-   */
-  for (i = 0; i < 3; i++) {
+  /* Find Euclidean vectors and angles between earth, object, and the sun */
+  for (var i = 0; i < 3; i++) {
     pp[i] = rect[i] * pol[2]
-    qq[i] = $moshier.body.earth.position.rect [i] + pp[i]
+    qq[i] = $moshier.body.earth.position.rect[i] + pp[i]
   }
   $util.angles(pp, qq, $moshier.body.earth.position.rect)
 
-  /* Make rect a unit vector.  */
-  /* for (i = 0; i < 3; i++) */
+  /* Make rect a unit vector. */
+  /* for (var i = 0; i < 3; i++) */
   /*  rect[i] /= EO; */
 
   /* Correct position for light deflection.
@@ -224,31 +212,32 @@ $ns.moon.calcll = function (date, rect, pol, result) {
 
   /* Aberration of light.
    The Astronomical Almanac (Section D, Daily Polynomial Coefficients)
-   seems to omit this, even though the reference ephemeris is inertial.  */
+   seems to omit this, even though the reference ephemeris is inertial. */
   /* annuab (rect); */
 
-  /* Precess to date.  */
+  /* Precess to date. */
   $moshier.precess.calc(rect, {julian: $moshier.body.earth.position.date.julian}, -1) // TDT
 
-  /* Correct for nutation at date TDT.
-   */
-  result.nutation = $moshier.nutation.calc({julian: $moshier.body.earth.position.date.julian}, rect) // TDT
+  /* Correct for nutation at date TDT. */
+  var result = {
+    nutation: $moshier.nutation.calc({julian: $moshier.body.earth.position.date.julian}, rect) // TDT
+  }
 
-  /* Apparent geocentric right ascension and declination.  */
+  /* Apparent geocentric right ascension and declination. */
   this.ra = $util.zatan2(rect[0], rect[1])
   this.dec = Math.asin(rect[2])
 
   /* For apparent ecliptic coordinates, rotate from the true
-   equator into the ecliptic of date.  */
+   equator into the ecliptic of date. */
   cosL = Math.cos($moshier.epsilon.eps + $moshier.nutation.nuto)
   sinL = Math.sin($moshier.epsilon.eps + $moshier.nutation.nuto)
-  y = cosL * rect[1] + sinL * rect[2]
-  z = -sinL * rect[1] + cosL * rect[2]
+  var y = cosL * rect[1] + sinL * rect[2]
+  var z = -sinL * rect[1] + cosL * rect[2]
   pol[0] = $util.zatan2(rect[0], y)
   pol[1] = Math.asin(z)
 
-  /* Restore earth-moon distance.  */
-  for (i = 0; i < 3; i++) {
+  /* Restore earth-moon distance. */
+  for (var i = 0; i < 3; i++) {
     rect[i] *= $const.EO
   }
 

--- a/src/astronomy/moshier/nutation.js
+++ b/src/astronomy/moshier/nutation.js
@@ -182,10 +182,10 @@ $ns.nutation.calc = function (date, p) {
 
   p1[1] = sl * ce * p[0]
     + (cl * $moshier.epsilon.coseps * ce + $moshier.epsilon.sineps * se) * p[1]
-    - (sino + (1.0 - cl) * $moshier.epsilon.sineps * ce) * p[2]
+    - (sino + (1 - cl) * $moshier.epsilon.sineps * ce) * p[2]
 
   p1[2] = sl * se * p[0]
-    + (sino + (cl - 1.0) * se * $moshier.epsilon.coseps) * p[1]
+    + (sino + (cl - 1) * se * $moshier.epsilon.coseps) * p[1]
     + (cl * $moshier.epsilon.sineps * se + $moshier.epsilon.coseps * ce) * p[2]
 
   for (var i = 0; i < 3; i++) {
@@ -205,17 +205,18 @@ $ns.nutation.calc = function (date, p) {
  * computed at Julian date J.
  */
 $ns.nutation.calclo = function (date) {
-  if (this.jdnut.julian == date.julian)
+  if (this.jdnut.julian == date.julian) {
     return 0
+  }
 
   this.jdnut = date
 
   /* Julian centuries from 2000 January 1.5,
    * barycentric dynamical time
    */
-  var T = (date.julian - 2451545.0) / 36525.0
+  var T = (date.julian - 2451545) / 36525
   var T2 = T * T
-  var T10 = T / 10.0
+  var T10 = T / 10
 
   /* Fundamental arguments in the FK5 reference system. */
 
@@ -264,26 +265,23 @@ $ns.nutation.calclo = function (date) {
   for (var i = 0; i < 105; i++) {
     /* argument of sine and cosine */
     var k
-    var k1 = 0
+    var k1 = false
     var cv = 0.0
     var sv = 0.0
     for (var m = 0; m < 5; m++) {
       var j = p[p_i++] // *p++;
       if (j) {
-        k = j
-        if (j < 0) {
-          k = -k
-        }
+        k = j < 0 ? -j : j
         var su = this.ss[m][k - 1]
         /* sin(k*angle) */
         if (j < 0) {
           su = -su
         }
         var cu = this.cc[m][k - 1]
-        if (k1 == 0) { /* set first angle */
+        if (!k1) { /* set first angle */
           sv = su
           cv = cu
-          k1 = 1
+          k1 = true
         } else { /* combine angles */
           var sw = su * cv + cu * sv
           cv = cu * cv - su * sv
@@ -293,23 +291,26 @@ $ns.nutation.calclo = function (date) {
     }
     /* longitude coefficient */
     var f = p[p_i++] // *p++;
-    if ((k = p[p_i++] /* *p++ */) != 0) {
+    k = p[p_i++] /* *p++ */
+    if (k != 0) {
       f += T10 * k
     }
 
     /* obliquity coefficient */
     var g = p[p_i++] // *p++;
-    if ((k = p[p_i++] /* *p++ */) != 0)
+    k = p[p_i++] /* *p++ */
+    if (k != 0) {
       g += T10 * k
+    }
 
     /* accumulate the terms */
     C += f * sv
     D += g * cv
   }
   /* first terms, not in table: */
-  C += (-1742. * T10 - 171996.) * this.ss[4][0]
+  C += (-1742 * T10 - 171996) * this.ss[4][0]
   /* sin(OM) */
-  D += (89. * T10 + 92025.) * this.cc[4][0]
+  D += (89 * T10 + 92025) * this.cc[4][0]
   /* cos(OM) */
   /*
    printf( "nutation: in longitude %.3f\", in obliquity %.3f\"\n", C, D );

--- a/src/astronomy/moshier/nutation.js
+++ b/src/astronomy/moshier/nutation.js
@@ -154,22 +154,19 @@ $ns.nutation = {
  * mean ecliptic and equinox of date.
  */
 $ns.nutation.calc = function (date, p) {
-  var ce, se, cl, sl, sino, f // double
   var dp = [], p1 = [] // double
-  var i // int
-  var result
 
   this.calclo(date)
   /* be sure we calculated nutl and nuto */
   $moshier.epsilon.calc(date)
   /* and also the obliquity of date */
 
-  f = $moshier.epsilon.eps + this.nuto
-  ce = Math.cos(f)
-  se = Math.sin(f)
-  sino = Math.sin(this.nuto)
-  cl = Math.cos(this.nutl)
-  sl = Math.sin(this.nutl)
+  var f = $moshier.epsilon.eps + this.nuto
+  var ce = Math.cos(f)
+  var se = Math.sin(f)
+  var sino = Math.sin(this.nuto)
+  var cl = Math.cos(this.nutl)
+  var sl = Math.sin(this.nutl)
 
   /* Apply adjustment
    * to equatorial rectangular coordinates of object.
@@ -191,13 +188,13 @@ $ns.nutation.calc = function (date, p) {
     + (sino + (cl - 1.0) * se * $moshier.epsilon.coseps) * p[1]
     + (cl * $moshier.epsilon.sineps * se + $moshier.epsilon.coseps * ce) * p[2]
 
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     dp[i] = p1[i] - p[i]
   }
 
-  result = $util.showcor(p, dp)
+  var result = $util.showcor(p, dp)
 
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     p[i] = p1[i]
   }
 
@@ -208,52 +205,46 @@ $ns.nutation.calc = function (date, p) {
  * computed at Julian date J.
  */
 $ns.nutation.calclo = function (date) {
-  var f, g, T, T2, T10 // double
-  var MM, MS, FF, DD, OM // double
-  var cu, su, cv, sv, sw // double
-  var C, D // double
-  var i, j, k, k1, m // int
-  var p // short array
-
   if (this.jdnut.julian == date.julian)
     return 0
+
   this.jdnut = date
 
   /* Julian centuries from 2000 January 1.5,
    * barycentric dynamical time
    */
-  T = (date.julian - 2451545.0) / 36525.0
-  T2 = T * T
-  T10 = T / 10.0
+  var T = (date.julian - 2451545.0) / 36525.0
+  var T2 = T * T
+  var T10 = T / 10.0
 
   /* Fundamental arguments in the FK5 reference system. */
 
   /* longitude of the mean ascending node of the lunar orbit
    * on the ecliptic, measured from the mean equinox of date
    */
-  OM = ($util.mods3600(-6962890.539 * T + 450160.280) + (0.008 * T + 7.455) * T2)
+  var OM = ($util.mods3600(-6962890.539 * T + 450160.280) + (0.008 * T + 7.455) * T2)
     * $const.STR
 
   /* mean longitude of the Sun minus the
    * mean longitude of the Sun's perigee
    */
-  MS = ($util.mods3600(129596581.224 * T + 1287099.804) - (0.012 * T + 0.577) * T2)
+  var MS = ($util.mods3600(129596581.224 * T + 1287099.804) - (0.012 * T + 0.577) * T2)
     * $const.STR
 
   /* mean longitude of the Moon minus the
    * mean longitude of the Moon's perigee
    */
-  MM = ($util.mods3600(1717915922.633 * T + 485866.733) + (0.064 * T + 31.310) * T2)
+  var MM = ($util.mods3600(1717915922.633 * T + 485866.733) + (0.064 * T + 31.310) * T2)
     * $const.STR
 
   /* mean longitude of the Moon minus the
    * mean longitude of the Moon's node
    */
-  FF = ($util.mods3600(1739527263.137 * T + 335778.877) + (0.011 * T - 13.257) * T2)
+  var FF = ($util.mods3600(1739527263.137 * T + 335778.877) + (0.011 * T - 13.257) * T2)
     * $const.STR
 
   /* mean elongation of the Moon from the Sun. */
-  DD = ($util.mods3600(1602961601.328 * T + 1072261.307) + (0.019 * T - 6.891) * T2)
+  var DD = ($util.mods3600(1602961601.328 * T + 1072261.307) + (0.019 * T - 6.891) * T2)
     * $const.STR
 
   /* Calculate sin( i*MM ), etc. for needed multiple angles */
@@ -263,51 +254,52 @@ $ns.nutation.calclo = function (date) {
   this.sscc(3, DD, 4)
   this.sscc(4, OM, 2)
 
-  C = 0.0
-  D = 0.0
-  p = this.nt
+  var C = 0.0
+  var D = 0.0
+  var p = this.nt
   /* point to start of table */
 
   var p_i = 0
 
-  for (i = 0; i < 105; i++) {
+  for (var i = 0; i < 105; i++) {
     /* argument of sine and cosine */
-    k1 = 0
-    cv = 0.0
-    sv = 0.0
-    for (m = 0; m < 5; m++) {
-      j = p [p_i++] //*p++;
+    var k
+    var k1 = 0
+    var cv = 0.0
+    var sv = 0.0
+    for (var m = 0; m < 5; m++) {
+      var j = p[p_i++] // *p++;
       if (j) {
         k = j
         if (j < 0) {
           k = -k
         }
-        su = this.ss[m][k - 1]
+        var su = this.ss[m][k - 1]
         /* sin(k*angle) */
         if (j < 0) {
           su = -su
         }
-        cu = this.cc[m][k - 1]
+        var cu = this.cc[m][k - 1]
         if (k1 == 0) { /* set first angle */
           sv = su
           cv = cu
           k1 = 1
         } else { /* combine angles */
-          sw = su * cv + cu * sv
+          var sw = su * cv + cu * sv
           cv = cu * cv - su * sv
           sv = sw
         }
       }
     }
     /* longitude coefficient */
-    f = p [p_i++] //*p++;
-    if ((k = p [p_i++] /* *p++ */) != 0) {
+    var f = p[p_i++] // *p++;
+    if ((k = p[p_i++] /* *p++ */) != 0) {
       f += T10 * k
     }
 
     /* obliquity coefficient */
-    g = p [p_i++] //*p++;
-    if ((k = p [p_i++] /* *p++ */) != 0)
+    var g = p[p_i++] // *p++;
+    if ((k = p[p_i++] /* *p++ */) != 0)
       g += T10 * k
 
     /* accumulate the terms */
@@ -331,11 +323,8 @@ $ns.nutation.calclo = function (date) {
  * for required multiple angles
  */
 $ns.nutation.sscc = function (k, arg, n) {
-  var cu, su, cv, sv, s // double
-  var i // int
-
-  su = Math.sin(arg)
-  cu = Math.cos(arg)
+  var su = Math.sin(arg)
+  var cu = Math.cos(arg)
   this.ss[k] = []
   this.cc[k] = []
 
@@ -343,13 +332,13 @@ $ns.nutation.sscc = function (k, arg, n) {
   /* sin(L) */
   this.cc[k][0] = cu
   /* cos(L) */
-  sv = 2.0 * su * cu
-  cv = cu * cu - su * su
+  var sv = 2 * su * cu
+  var cv = cu * cu - su * su
   this.ss[k][1] = sv
   /* sin(2L) */
   this.cc[k][1] = cv
-  for (i = 2; i < n; i++) {
-    s = su * cv + cu * sv
+  for (var i = 2; i < n; i++) {
+    var s = su * cv + cu * sv
     cv = cu * cv - su * sv
     sv = s
     this.ss[k][i] = sv

--- a/src/astronomy/moshier/planet.js
+++ b/src/astronomy/moshier/planet.js
@@ -15,33 +15,30 @@ $ns.planet.calc = function (body) {
  * right ascension and declination.
  */
 $ns.planet.reduce = function (body, q, e) {
-  var p = [], temp = [], polar = [] // double
-  var a, b, s // double
-  var i // int
+  var p = [], temp = [] // double
 
   /* Save the geometric coordinates at TDT */
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     temp[i] = q[i]
   }
 
   /* Display ecliptic longitude and latitude, precessed to equinox
    of date. */
-  body.equinoxEclipticLonLat = $moshier.lonlat.calc(q, $moshier.body.earth.position.date, polar, 1)
+  var polar = body.equinoxEclipticLonLat = $moshier.lonlat.calc(q, $moshier.body.earth.position.date, true)
 
   /* Adjust for light time (planetary aberration) */
   $moshier.light.calc(body, q, e)
 
-  /* Find Euclidean vectors between earth, object, and the sun
-   */
-  for (i = 0; i < 3; i++) {
+  /* Find Euclidean vectors between earth, object, and the sun */
+  for (var i = 0; i < 3; i++) {
     p[i] = q[i] - e[i]
   }
 
   $util.angles(p, q, e)
 
-  a = 0.0
-  for (i = 0; i < 3; i++) {
-    b = temp[i] - e[i]
+  var a = 0.0
+  for (var i = 0; i < 3; i++) {
+    var b = temp[i] - e[i]
     a += b * b
   }
   a = Math.sqrt(a)
@@ -63,16 +60,15 @@ $ns.planet.reduce = function (body, q, e) {
    * Note this phase term estimate does not reflect reality well.
    * Calculated magnitudes of Mercury and Venus are inaccurate.
    */
-  b = 0.5 * (1.01 + 0.99 * $const.pq)
-  s = body.magnitude + 2.1715 * Math.log($const.EO * $const.SO) - 1.085 * Math.log(b)
+  var b = 0.5 * (1.01 + 0.99 * $const.pq)
+  var s = body.magnitude + 2.1715 * Math.log($const.EO * $const.SO) - 1.085 * Math.log(b)
   body.position.approxVisual = {
     magnitude: s,
     phase: a
   }
 
-  /* Find unit vector from earth in direction of object
-   */
-  for (i = 0; i < 3; i++) {
+  /* Find unit vector from earth in direction of object */
+  for (var i = 0; i < 3; i++) {
     p[i] /= $const.EO
     temp[i] = p[i]
   }
@@ -106,20 +102,20 @@ $ns.planet.reduce = function (body, q, e) {
   body.position.apparent = $util.showrd(p, polar)
 
   /* Geocentric ecliptic longitude and latitude. */
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     p[i] *= $const.EO
   }
-  body.position.apparentGeocentric = $moshier.lonlat.calc(p, $moshier.body.earth.position.date, temp, 0)
-  body.position.apparentLongitude = body.position.apparentGeocentric [0] * $const.RTD
+  body.position.apparentGeocentric = $moshier.lonlat.calc(p, $moshier.body.earth.position.date, false)
+  body.position.apparentLongitude = body.position.apparentGeocentric[0] * $const.RTD
   body.position.apparentLongitudeString =
-    body.position.apparentGeocentric [3].degree + '\u00B0' +
-    body.position.apparentGeocentric [3].minutes + '\'' +
-    Math.floor(body.position.apparentGeocentric [3].seconds) + '"'
+    body.position.apparentGeocentric[3].degree + '\u00B0' +
+    body.position.apparentGeocentric[3].minutes + '\'' +
+    Math.floor(body.position.apparentGeocentric[3].seconds) + '"'
 
   body.position.apparentLongitude30String =
-    $util.mod30(body.position.apparentGeocentric [3].degree) + '\u00B0' +
-    body.position.apparentGeocentric [3].minutes + '\'' +
-    Math.floor(body.position.apparentGeocentric [3].seconds) + '"'
+    $util.mod30(body.position.apparentGeocentric[3].degree) + '\u00B0' +
+    body.position.apparentGeocentric[3].minutes + '\'' +
+    Math.floor(body.position.apparentGeocentric[3].seconds) + '"'
 
   body.position.geocentricDistance = -1
 

--- a/src/astronomy/moshier/planet.js
+++ b/src/astronomy/moshier/planet.js
@@ -44,7 +44,7 @@ $ns.planet.reduce = function (body, q, e) {
   a = Math.sqrt(a)
   body.position.trueGeocentricDistance = a
   /* was EO */
-  body.position.equatorialDiameter = 2.0 * body.semiDiameter / $const.EO
+  body.position.equatorialDiameter = 2 * body.semiDiameter / $const.EO
 
   /* Calculate visual magnitude.
    * "Visual" refers to the spectrum of visible light.
@@ -55,7 +55,7 @@ $ns.planet.reduce = function (body, q, e) {
    * where V(1,0) = elemnt->mag is the magnitude at 1au from
    * both earth and sun and 100% illumination.
    */
-  a = 0.5 * (1.0 + $const.pq)
+  a = 0.5 * (1 + $const.pq)
   /* Fudge the phase for light leakage in magnitude estimation.
    * Note this phase term estimate does not reflect reality well.
    * Calculated magnitudes of Mercury and Venus are inaccurate.

--- a/src/astronomy/moshier/precess.js
+++ b/src/astronomy/moshier/precess.js
@@ -53,11 +53,11 @@ $ns.precess.calc = function (R, date, direction) {
    * to the ecliptic. (The input is equatorial.)
    */
   if (direction == 1) {
-    $moshier.epsilon.calc(date)
     /* To J2000 */
+    $moshier.epsilon.calc(date)
   } else {
-    $moshier.epsilon.calc({julian: $const.j2000})
     /* From J2000 */
+    $moshier.epsilon.calc({julian: $const.j2000})
   }
   x[0] = R[0]
   var z = $moshier.epsilon.coseps * R[1] + $moshier.epsilon.sineps * R[2]

--- a/src/astronomy/moshier/precess.js
+++ b/src/astronomy/moshier/precess.js
@@ -46,7 +46,7 @@ $ns.precess.calc = function (R, date, direction) {
   /* Each precession angle is specified by a polynomial in
    * T = Julian centuries from J2000.0.  See AA page B18.
    */
-  var T = (date.julian - $const.j2000) / 36525.0
+  var T = (date.julian - $const.j2000) / 36525
 
   /* Implementation by elementary rotations using Laskar's expansions.
    * First rotate about the x axis from the initial equator
@@ -65,7 +65,7 @@ $ns.precess.calc = function (R, date, direction) {
   x[1] = z
 
   /* Precession in longitude */
-  T /= 10.0
+  T /= 10
   /* thousands of years */
   var p = this.pAcof
   var pA = p[p_i++] // *p++;

--- a/src/astronomy/moshier/precess.js
+++ b/src/astronomy/moshier/precess.js
@@ -1,19 +1,19 @@
 $ns.precess = {
   /* In WILLIAMS and SIMON, Laskar's terms of order higher than t^4
    have been retained, because Simon et al mention that the solution
-   is the same except for the lower order terms.  */
+   is the same except for the lower order terms. */
   pAcof: [
-    /* Corrections to Williams (1994) introduced in DE403.  */
+    /* Corrections to Williams (1994) introduced in DE403. */
     -8.66e-10, -4.759e-8, 2.424e-7, 1.3095e-5, 1.7451e-4, -1.8055e-3,
     -0.235316, 0.076, 110.5414, 50287.91959
   ],
-  /* Pi from Williams' 1994 paper, in radians.  No change in DE403.  */
+  /* Pi from Williams' 1994 paper, in radians.  No change in DE403. */
   nodecof: [
     6.6402e-16, -2.69151e-15, -1.547021e-12, 7.521313e-12, 1.9e-10,
     -3.54e-9, -1.8103e-7, 1.26e-7, 7.436169e-5,
     -0.04207794833, 3.052115282424
   ],
-  /* pi from Williams' 1994 paper, in radians.  No change in DE403.  */
+  /* pi from Williams' 1994 paper, in radians.  No change in DE403. */
   inclcof: [
     1.2147e-16, 7.3759e-17, -8.26287e-14, 2.503410e-13, 2.4650839e-11,
     -5.4000441e-11, 1.32115526e-9, -6.012e-7, -1.62442e-5,
@@ -37,11 +37,8 @@ $ns.precess = {
  * to go from J2000 to J2.
  */
 $ns.precess.calc = function (R, date, direction) {
-  var A, B, T, pA, W, z // double
   var x = [] // double
-  var p // double array
   var p_i = 0
-  var i // int
 
   if (date.julian == $const.j2000) {
     return
@@ -49,7 +46,7 @@ $ns.precess.calc = function (R, date, direction) {
   /* Each precession angle is specified by a polynomial in
    * T = Julian centuries from J2000.0.  See AA page B18.
    */
-  T = (date.julian - $const.j2000) / 36525.0
+  var T = (date.julian - $const.j2000) / 36525.0
 
   /* Implementation by elementary rotations using Laskar's expansions.
    * First rotate about the x axis from the initial equator
@@ -63,39 +60,36 @@ $ns.precess.calc = function (R, date, direction) {
     /* From J2000 */
   }
   x[0] = R[0]
-  z = $moshier.epsilon.coseps * R[1] + $moshier.epsilon.sineps * R[2]
+  var z = $moshier.epsilon.coseps * R[1] + $moshier.epsilon.sineps * R[2]
   x[2] = -$moshier.epsilon.sineps * R[1] + $moshier.epsilon.coseps * R[2]
   x[1] = z
 
-  /* Precession in longitude
-   */
+  /* Precession in longitude */
   T /= 10.0
   /* thousands of years */
-  p = this.pAcof
-  pA = p [p_i++] //*p++;
-  for (i = 0; i < 9; i++) {
-    pA = pA * T + p [p_i++] //*p++;
+  var p = this.pAcof
+  var pA = p[p_i++] // *p++;
+  for (var i = 0; i < 9; i++) {
+    pA = pA * T + p[p_i++] // *p++;
   }
   pA *= $const.STR * T
 
-  /* Node of the moving ecliptic on the J2000 ecliptic.
-   */
+  /* Node of the moving ecliptic on the J2000 ecliptic. */
   p = this.nodecof
   p_i = 0
-  W = p [p_i++] //*p++;
-  for (i = 0; i < 10; i++) {
-    W = W * T + p [p_i++] //*p++;
+  var W = p[p_i++] // *p++;
+  for (var i = 0; i < 10; i++) {
+    W = W * T + p[p_i++] // *p++;
   }
 
-  /* Rotate about z axis to the node.
-   */
+  /* Rotate about z axis to the node. */
   if (direction == 1) {
     z = W + pA
   } else {
     z = W
   }
-  B = Math.cos(z)
-  A = Math.sin(z)
+  var B = Math.cos(z)
+  var A = Math.sin(z)
   z = B * x[0] + A * x[1]
   x[1] = -A * x[0] + B * x[1]
   x[0] = z
@@ -105,9 +99,9 @@ $ns.precess.calc = function (R, date, direction) {
    */
   p = this.inclcof
   p_i = 0
-  z = p [p_i++] //*p++;
-  for (i = 0; i < 10; i++) {
-    z = z * T + p [p_i++] //*p++;
+  z = p[p_i++] // *p++;
+  for (var i = 0; i < 10; i++) {
+    z = z * T + p[p_i++] // *p++;
   }
   if (direction == 1) {
     z = -z
@@ -118,8 +112,7 @@ $ns.precess.calc = function (R, date, direction) {
   x[2] = -A * x[1] + B * x[2]
   x[1] = z
 
-  /* Rotate about new z axis back from the node.
-   */
+  /* Rotate about new z axis back from the node. */
   if (direction == 1) {
     z = -W
   } else {
@@ -131,8 +124,7 @@ $ns.precess.calc = function (R, date, direction) {
   x[1] = -A * x[0] + B * x[1]
   x[0] = z
 
-  /* Rotate about x axis to final equator.
-   */
+  /* Rotate about x axis to final equator. */
   if (direction == 1) {
     $moshier.epsilon.calc({julian: $const.j2000})
   } else {
@@ -142,7 +134,7 @@ $ns.precess.calc = function (R, date, direction) {
   x[2] = $moshier.epsilon.sineps * x[1] + $moshier.epsilon.coseps * x[2]
   x[1] = z
 
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     R[i] = x[i]
   }
 }

--- a/src/astronomy/moshier/processor.js
+++ b/src/astronomy/moshier/processor.js
@@ -50,8 +50,6 @@ $ns.processor.init = function () {
 }
 
 $ns.processor.test = function () {
-  var body, date
-
   // tested position
   $copy($const, {
     tlong: -71.13,
@@ -65,8 +63,8 @@ $ns.processor.test = function () {
   this.init()
 
   // test the moon
-  date = {year: 1986, month: 1, day: 1, hours: 1, minutes: 52, seconds: 0}
-  body = $moshier.body.moon
+  var date = {year: 1986, month: 1, day: 1, hours: 1, minutes: 52, seconds: 0}
+  var body = $moshier.body.moon
   this.calc(date, body)
 
   $assert(date.julian, 2446431.577777778)
@@ -141,25 +139,6 @@ $ns.processor.test = function () {
   $assert(body.position.altaz.topocentric.ra, -1.3624315255707726)
   $assert(body.position.altaz.topocentric.dec, -0.4006666463910222)
   $assert(body.position.altaz.topocentric.azimuth, 179.48488458374226)
-
-  // test sirius
-  date = {year: 1986, month: 1, day: 1, hours: 0, minutes: 0, seconds: 0}
-  body = $moshier.body.sirius
-  this.calc(date, body)
-
-  $assert(date.julian, 2446431.5)
-  $assert(date.delta, 54.87)
-
-  $assert(body.position.apparent.dRA, 1.7651675096112047)
-  $assert(body.position.apparent.dDec, -0.29137543179606207)
-
-  $assert(body.position.astrometricDate.dRA, 1.7651002655957506)
-  $assert(body.position.astrometricDate.dDec, -0.29140596467162816)
-
-  $assert(body.position.altaz.topocentric.altitude, 1.7060953673767152)
-  $assert(body.position.altaz.topocentric.ra, -4.522192086886859)
-  $assert(body.position.altaz.topocentric.dec, -0.2873401996237649)
-  $assert(body.position.altaz.topocentric.azimuth, 114.21923743994829)
 
   // test sirius
   date = {year: 1986, month: 1, day: 1, hours: 0, minutes: 0, seconds: 0}

--- a/src/astronomy/moshier/processor.js
+++ b/src/astronomy/moshier/processor.js
@@ -41,7 +41,7 @@ $ns.processor.calc = function (date, body) {
 $ns.processor.ecliptic = function (date, observer, body) {
   this.calc(date, observer)
   this.calc(date, body)
-  // this.reduce (observer, body);
+  // this.reduce(observer, body)
 }
 
 $ns.processor.init = function () {
@@ -112,9 +112,9 @@ $ns.processor.test = function () {
   $assert(date.julian, 2446432.199305556)
   $assert(date.delta, 54.87089572485891)
 
-  $assert(body.position.equinoxEclipticLonLat [0], 4.90413951369789)
-  $assert(body.position.equinoxEclipticLonLat [1], 0.000002184617423267333)
-  $assert(body.position.equinoxEclipticLonLat [2], 0.9832794756330766)
+  $assert(body.position.equinoxEclipticLonLat[0], 4.90413951369789)
+  $assert(body.position.equinoxEclipticLonLat[1], 0.000002184617423267333)
+  $assert(body.position.equinoxEclipticLonLat[2], 0.9832794756330766)
 
   $assert(body.position.lightTime, 8.177686171897745)
 

--- a/src/astronomy/moshier/refraction.js
+++ b/src/astronomy/moshier/refraction.js
@@ -5,9 +5,6 @@ $ns.refraction = {}
  * to obtain apparent altitude.
  */
 $ns.refraction.calc = function (alt) {
-  var y, y0, D0, N, D, P, Q // double
-  var i // int
-
   if (alt < -2.0 || alt >= 90.0) {
     return 0.0
   }
@@ -16,8 +13,7 @@ $ns.refraction.calc = function (alt) {
    * Accuracy "usually about 0.1' ".
    */
   if (alt > 15.0) {
-    D = 0.00452 * $const.atpress / ((273.0 + $const.attemp) * Math.tan($const.DTR * alt))
-    return D
+    return 0.00452 * $const.atpress / ((273.0 + $const.attemp) * Math.tan($const.DTR * alt))
   }
 
   /* Formula for low altitude is from the Almanac for Computers.
@@ -27,16 +23,16 @@ $ns.refraction.calc = function (alt) {
    */
 
   /* Start iteration assuming correction = 0 */
-  y = alt
-  D = 0.0
+  var y = alt
+  var D = 0.0
   /* Invert Almanac for Computers formula numerically */
-  P = ($const.atpress - 80.0) / 930.0
-  Q = 4.8e-3 * ($const.attemp - 10.0)
-  y0 = y
-  D0 = D
+  var P = ($const.atpress - 80.0) / 930.0
+  var Q = 4.8e-3 * ($const.attemp - 10.0)
+  var y0 = y
+  var D0 = D
 
-  for (i = 0; i < 4; i++) {
-    N = y + (7.31 / (y + 4.4))
+  for (var i = 0; i < 4; i++) {
+    var N = y + (7.31 / (y + 4.4))
     N = 1.0 / Math.tan($const.DTR * N)
     D = N * P / (60.0 + Q * (N + 39.0))
     N = y - y0

--- a/src/astronomy/moshier/refraction.js
+++ b/src/astronomy/moshier/refraction.js
@@ -12,7 +12,7 @@ $ns.refraction.calc = function (alt) {
   /* For high altitude angle, AA page B61
    * Accuracy "usually about 0.1' ".
    */
-  if (alt > 15.0) {
+  if (alt > 15) {
     return 0.00452 * $const.atpress / ((273 + $const.attemp) * Math.tan($const.DTR * alt))
   }
 

--- a/src/astronomy/moshier/refraction.js
+++ b/src/astronomy/moshier/refraction.js
@@ -5,15 +5,15 @@ $ns.refraction = {}
  * to obtain apparent altitude.
  */
 $ns.refraction.calc = function (alt) {
-  if (alt < -2.0 || alt >= 90.0) {
-    return 0.0
+  if (alt < -2 || alt >= 90) {
+    return 0
   }
 
   /* For high altitude angle, AA page B61
    * Accuracy "usually about 0.1' ".
    */
   if (alt > 15.0) {
-    return 0.00452 * $const.atpress / ((273.0 + $const.attemp) * Math.tan($const.DTR * alt))
+    return 0.00452 * $const.atpress / ((273 + $const.attemp) * Math.tan($const.DTR * alt))
   }
 
   /* Formula for low altitude is from the Almanac for Computers.
@@ -26,15 +26,15 @@ $ns.refraction.calc = function (alt) {
   var y = alt
   var D = 0.0
   /* Invert Almanac for Computers formula numerically */
-  var P = ($const.atpress - 80.0) / 930.0
-  var Q = 4.8e-3 * ($const.attemp - 10.0)
+  var P = ($const.atpress - 80) / 930
+  var Q = 4.8e-3 * ($const.attemp - 10)
   var y0 = y
   var D0 = D
 
   for (var i = 0; i < 4; i++) {
     var N = y + (7.31 / (y + 4.4))
-    N = 1.0 / Math.tan($const.DTR * N)
-    D = N * P / (60.0 + Q * (N + 39.0))
+    N = 1 / Math.tan($const.DTR * N)
+    D = N * P / (60 + Q * (N + 39))
     N = y - y0
     y0 = D - D0 - N
     /* denominator of derivative */

--- a/src/astronomy/moshier/sidereal.js
+++ b/src/astronomy/moshier/sidereal.js
@@ -14,12 +14,12 @@ $ns.sidereal.calc = function (date, tlong) {
     jd0 += 0.5
     secs -= 0.5
   }
-  secs *= 86400.0
+  secs *= 86400
 
   /* Julian centuries from standard epoch J2000.0 */
   /* T = (jd - J2000)/36525.0; */
   /* Same but at 0h Universal Time of date */
-  var T0 = (jd0 - $const.j2000) / 36525.0
+  var T0 = (jd0 - $const.j2000) / 36525
 
   /* The equation of the equinoxes is the nutation in longitude
    * times the cosine of the obliquity of the ecliptic.
@@ -30,18 +30,18 @@ $ns.sidereal.calc = function (date, tlong) {
   /* nutl is in radians; convert to seconds of time
    * at 240 seconds per degree
    */
-  var eqeq = 240.0 * $const.RTD * $moshier.nutation.nutl * $moshier.epsilon.coseps
+  var eqeq = 240 * $const.RTD * $moshier.nutation.nutl * $moshier.epsilon.coseps
   /* Greenwich Mean Sidereal Time at 0h UT of date */
   /* Corrections to Williams (1994) introduced in DE403. */
   var gmst = (((-2.0e-6 * T0 - 3.e-7) * T0 + 9.27701e-2) * T0 + 8640184.7942063) * T0
     + 24110.54841
-  var msday = (((-(4. * 2.0e-6) * T0 - (3. * 3.e-7)) * T0 + (2. * 9.27701e-2)) * T0
-    + 8640184.7942063) / (86400. * 36525.) + 1.0
+  var msday = (((-(4 * 2.0e-6) * T0 - (3 * 3.e-7)) * T0 + (2 * 9.27701e-2)) * T0
+    + 8640184.7942063) / (86400 * 36525) + 1
 
   /* Local apparent sidereal time at given UT */
-  gmst = gmst + msday * secs + eqeq + 240.0 * tlong
+  gmst = gmst + msday * secs + eqeq + 240 * tlong
   /* Sidereal seconds modulo 1 sidereal day */
-  gmst = gmst - 86400.0 * Math.floor(gmst / 86400.0)
+  gmst = gmst - 86400 * Math.floor(gmst / 86400)
   /*
    * var il = gmst/86400.0;
    * gmst = gmst - 86400.0 * il;

--- a/src/astronomy/moshier/sidereal.js
+++ b/src/astronomy/moshier/sidereal.js
@@ -1,15 +1,12 @@
 $ns.sidereal = {}
 
 $ns.sidereal.calc = function (date, tlong) {
-  var jd0 // double    /* Julian day at midnight Universal Time */
-  var secs // double  /* Time of day, UT seconds since UT midnight */
-  var eqeq, gmst, jd, T0, msday // double
-  /*long il;*/
-
   /* Julian day at given UT */
-  jd = date.universal // UT
-  jd0 = Math.floor(jd)
-  secs = date.julian - jd0 // UT
+  var jd = date.universal // UT
+  /* Julian day at midnight Universal Time */
+  var jd0 = Math.floor(jd)
+  /* Time of day, UT seconds since UT midnight */
+  var secs = date.julian - jd0 // UT
   if (secs < 0.5) {
     jd0 -= 0.5
     secs += 0.5
@@ -22,7 +19,7 @@ $ns.sidereal.calc = function (date, tlong) {
   /* Julian centuries from standard epoch J2000.0 */
   /* T = (jd - J2000)/36525.0; */
   /* Same but at 0h Universal Time of date */
-  T0 = (jd0 - $const.j2000) / 36525.0
+  var T0 = (jd0 - $const.j2000) / 36525.0
 
   /* The equation of the equinoxes is the nutation in longitude
    * times the cosine of the obliquity of the ecliptic.
@@ -33,12 +30,12 @@ $ns.sidereal.calc = function (date, tlong) {
   /* nutl is in radians; convert to seconds of time
    * at 240 seconds per degree
    */
-  eqeq = 240.0 * $const.RTD * $moshier.nutation.nutl * $moshier.epsilon.coseps
+  var eqeq = 240.0 * $const.RTD * $moshier.nutation.nutl * $moshier.epsilon.coseps
   /* Greenwich Mean Sidereal Time at 0h UT of date */
-  /* Corrections to Williams (1994) introduced in DE403.  */
-  gmst = (((-2.0e-6 * T0 - 3.e-7) * T0 + 9.27701e-2) * T0 + 8640184.7942063) * T0
+  /* Corrections to Williams (1994) introduced in DE403. */
+  var gmst = (((-2.0e-6 * T0 - 3.e-7) * T0 + 9.27701e-2) * T0 + 8640184.7942063) * T0
     + 24110.54841
-  msday = (((-(4. * 2.0e-6) * T0 - (3. * 3.e-7)) * T0 + (2. * 9.27701e-2)) * T0
+  var msday = (((-(4. * 2.0e-6) * T0 - (3. * 3.e-7)) * T0 + (2. * 9.27701e-2)) * T0
     + 8640184.7942063) / (86400. * 36525.) + 1.0
 
   /* Local apparent sidereal time at given UT */
@@ -46,7 +43,7 @@ $ns.sidereal.calc = function (date, tlong) {
   /* Sidereal seconds modulo 1 sidereal day */
   gmst = gmst - 86400.0 * Math.floor(gmst / 86400.0)
   /*
-   * il = gmst/86400.0;
+   * var il = gmst/86400.0;
    * gmst = gmst - 86400.0 * il;
    * if( gmst < 0.0 )
    *	gmst += 86400.0;

--- a/src/astronomy/moshier/star.js
+++ b/src/astronomy/moshier/star.js
@@ -10,22 +10,20 @@ $ns.star.calc = function (body) {
 
 $ns.star.reduce = function (body) {
   var p = [], q = [], e = [], m = [], temp = [], polar = [] // double
-  var T, vpi, epoch // double
-  var cosdec, sindec, cosra, sinra // double
-  var i // int
+  var epoch // double
 
   /* Convert from RA and Dec to equatorial rectangular direction */
   do {
-    cosdec = Math.cos(body.dec)
-    sindec = Math.sin(body.dec)
-    cosra = Math.cos(body.ra)
-    sinra = Math.sin(body.ra)
+    var cosdec = Math.cos(body.dec)
+    var sindec = Math.sin(body.dec)
+    var cosra = Math.cos(body.ra)
+    var sinra = Math.sin(body.ra)
     q[0] = cosra * cosdec
     q[1] = sinra * cosdec
     q[2] = sindec
 
     /* space motion */
-    vpi = 21.094952663 * body.velocity * body.parallax
+    var vpi = 21.094952663 * body.velocity * body.parallax
     m[0] = -body.raMotion * cosdec * sinra
       - body.decMotion * sindec * cosra
       + vpi * q[0]
@@ -46,7 +44,7 @@ $ns.star.reduce = function (body) {
     }
   } while (epoch == $const.b1950)
 
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     e[i] = $moshier.body.earth.position.rect[i]
   }
 
@@ -54,16 +52,16 @@ $ns.star.reduce = function (body) {
   $moshier.precess.calc(e, {julian: epoch}, -1)
 
   /* Correct for proper motion and parallax */
-  T = ($moshier.body.earth.position.date.julian - epoch) / 36525.0
-  for (i = 0; i < 3; i++) {
+  var T = ($moshier.body.earth.position.date.julian - epoch) / 36525.0
+  for (var i = 0; i < 3; i++) {
     p[i] = q[i] + T * m[i] - body.parallax * e[i]
   }
 
   /* precess the star to J2000 */
   $moshier.precess.calc(p, {julian: epoch}, 1)
   /* reset the earth to J2000 */
-  for (i = 0; i < 3; i++) {
-    e[i] = $moshier.body.earth.position.rect [i]
+  for (var i = 0; i < 3; i++) {
+    e[i] = $moshier.body.earth.position.rect[i]
   }
 
   /* Find Euclidean vectors between earth, object, and the sun
@@ -72,7 +70,7 @@ $ns.star.reduce = function (body) {
   $util.angles(p, p, e)
 
   /* Find unit vector from earth in direction of object */
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     p[i] /= $const.EO
     temp[i] = p[i]
   }
@@ -89,7 +87,7 @@ $ns.star.reduce = function (body) {
   body.position.astrometricB1950 = $util.showrd(temp, polar)
 
   /* For equinox of date: */
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     temp[i] = p[i]
   }
 
@@ -136,25 +134,19 @@ $ns.star.reduce = function (body) {
   /* Go do topocentric reductions. */
   $const.dradt = 0.0
   $const.ddecdt = 0.0
-  polar [2] = 1.0e38
+  polar[2] = 1.0e38
   /* make it ignore diurnal parallax */
 
   body.position.altaz = $moshier.altaz.calc(polar, $moshier.body.earth.position.date)
 }
 
 $ns.star.prepare = function (body) {
-  var sign // int
-  var s // char array
-  var x, z // double
-  var p // char array
-  var i // int
-
   /* Read in the ASCII string data and name of the object */
   // sscanf( s, "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %s",
   //   &body->epoch, &rh, &rm, &rs, &dd, &dm, &ds,
   //   &body->mura, &body->mudec, &body->v, &body->px, &body->mag, &body->obname[0] );
 
-  x = body.epoch
+  var x = body.epoch
   if (x == 2000.0) {
     x = $const.j2000
   } else if (x == 1950.0) {
@@ -173,13 +165,12 @@ $ns.star.prepare = function (body) {
 
   /* read the declination */
   if (!body.dec) {
-    sign = 1
-
+    var sign = 1
     /* the '-' sign may appaer at any part of hmsDec */
     if (body.hmsDec.hours < 0.0 || body.hmsDec.minutes < 0.0 || body.hmsDec.seconds < 0.0) {
       sign = -1
     }
-    z = (3600.0 * Math.abs(body.hmsDec.hours) + 60.0 * Math.abs(body.hmsDec.minutes) + Math.abs(body.hmsDec.seconds)) / $const.RTS
+    var z = (3600.0 * Math.abs(body.hmsDec.hours) + 60.0 * Math.abs(body.hmsDec.minutes) + Math.abs(body.hmsDec.seconds)) / $const.RTS
     if (sign < 0) {
       z = -z
     }

--- a/src/astronomy/moshier/star.js
+++ b/src/astronomy/moshier/star.js
@@ -52,7 +52,7 @@ $ns.star.reduce = function (body) {
   $moshier.precess.calc(e, {julian: epoch}, -1)
 
   /* Correct for proper motion and parallax */
-  var T = ($moshier.body.earth.position.date.julian - epoch) / 36525.0
+  var T = ($moshier.body.earth.position.date.julian - epoch) / 36525
   for (var i = 0; i < 3; i++) {
     p[i] = q[i] + T * m[i] - body.parallax * e[i]
   }
@@ -154,42 +154,32 @@ $ns.star.prepare = function (body) {
   } else if (x == 1900.0) {
     x = $const.j1900
   } else {
-    x = $const.j2000 + 365.25 * (x - 2000.0)
+    x = $const.j2000 + 365.25 * (x - 2000)
   }
   body.epoch = x
 
   /* read the right ascension */
   if (!body.ra) {
-    body.ra = 2.0 * Math.PI * (3600.0 * body.hmsRa.hours + 60.0 * body.hmsRa.minutes + body.hmsRa.seconds) / 86400.0
+    body.ra = 2 * Math.PI * (3600 * body.hmsRa.hours + 60 * body.hmsRa.minutes + body.hmsRa.seconds) / 86400
   }
 
   /* read the declination */
   if (!body.dec) {
-    var sign = 1
     /* the '-' sign may appaer at any part of hmsDec */
-    if (body.hmsDec.hours < 0.0 || body.hmsDec.minutes < 0.0 || body.hmsDec.seconds < 0.0) {
-      sign = -1
-    }
-    var z = (3600.0 * Math.abs(body.hmsDec.hours) + 60.0 * Math.abs(body.hmsDec.minutes) + Math.abs(body.hmsDec.seconds)) / $const.RTS
-    if (sign < 0) {
-      z = -z
-    }
-    body.dec = z
+    var sign = body.hmsDec.hours < 0 || body.hmsDec.minutes < 0 || body.hmsDec.seconds < 0 ? -1 : 1
+    var z = (3600 * Math.abs(body.hmsDec.hours) + 60 * Math.abs(body.hmsDec.minutes) + Math.abs(body.hmsDec.seconds)) / $const.RTS
+    body.dec = sign < 0 ? -z : z
   }
 
-  body.raMotion *= 15.0 / $const.RTS
+  body.raMotion *= 15 / $const.RTS
   /* s/century -> "/century -> rad/century */
   body.decMotion /= $const.RTS
-  z = body.parallax
-  if (z < 1.0) {
-    if (z <= 0.0) {
-      body.parallax = 0.0
-    } else {
-      body.parallax = $const.STR * z
-      /* assume px in arc seconds */
-    }
+  var p = body.parallax
+  if (p < 1) {
+    /* assume px in arc seconds */
+    body.parallax = p <= 0 ? 0 : $const.STR * p
   } else {
-    body.parallax = 1.0 / ($const.RTS * z)
+    body.parallax = 1 / ($const.RTS * p)
     /* parsecs -> radians */
   }
 }

--- a/src/astronomy/moshier/sun.js
+++ b/src/astronomy/moshier/sun.js
@@ -32,18 +32,17 @@ $ns.sun.calc = function () {
 
   for (var i = 0; i < 3; i++) {
     var x = -ecr[i]
-    var y = -$moshier.body.earth.position.rect[i] // -rearth[i];
-    ecr[i] = x
     /* position t days ago */
-    rec[i] = y
+    ecr[i] = x
     /* position now */
-    pol[i] = y - x
+    rec[i] = -$moshier.body.earth.position.rect[i] // -rearth[i];
     /* change in position */
+    pol[i] = rec[i] - x
   }
 
   $copy($moshier.body.sun.position, {
     date: $moshier.body.earth.position.date,
-    lightTime: 1440.0 * t,
+    lightTime: 1440 * t,
     aberration: $util.showcor(ecr, pol)
   })
 
@@ -51,7 +50,7 @@ $ns.sun.calc = function () {
    * for use by altaz().
    */
   var d = $util.deltap(ecr, rec)
-  /* see dms.c */
+  /* see $util.dms() */
   $const.dradt = d.dr
   $const.ddecdt = d.dd
   $const.dradt /= t
@@ -80,7 +79,7 @@ $ns.sun.calc = function () {
   $moshier.body.sun.position.apparent = $util.showrd(ecr, pol)
 
   /* Show it in ecliptic coordinates */
-  y = $moshier.epsilon.coseps * rec[1] + $moshier.epsilon.sineps * rec[2]
+  var y = $moshier.epsilon.coseps * rec[1] + $moshier.epsilon.sineps * rec[2]
   y = $util.zatan2(rec[0], y) + $moshier.nutation.nutl
   $moshier.body.sun.position.apparentLongitude = $const.RTD * y
   var dmsLongitude = $util.dms(y)

--- a/src/astronomy/moshier/sun.js
+++ b/src/astronomy/moshier/sun.js
@@ -1,21 +1,17 @@
 $ns.sun = {}
 
 $ns.sun.calc = function () {
-  var r, x, y, t // double
-  var ecr = [], rec = [], pol = [] // double
-  var i // int
-  var d
-  //double asin(), modtp(), sqrt(), cos(), sin();
+  var t, ecr = [], rec = [] // double
 
   $moshier.body.sun.position = $moshier.body.sun.position || {}
 
   /* Display ecliptic longitude and latitude. */
-  for (i = 0; i < 3; i++) {
-    ecr[i] = -$moshier.body.earth.position.rect [i]//-rearth[i];
+  for (var i = 0; i < 3; i++) {
+    ecr[i] = -$moshier.body.earth.position.rect[i] // -rearth[i];
   }
-  r = $moshier.body.earth.position.polar [2] //eapolar [2];
+  var r = $moshier.body.earth.position.polar[2] // eapolar[2];
 
-  $moshier.body.sun.position.equinoxEclipticLonLat = $moshier.lonlat.calc(ecr, $moshier.body.earth.position.date, pol, 1) // TDT
+  var pol = $moshier.body.sun.position.equinoxEclipticLonLat = $moshier.lonlat.calc(ecr, $moshier.body.earth.position.date, true) // TDT
 
   /* Philosophical note: the light time correction really affects
    * only the Sun's barycentric position; aberration is due to
@@ -26,17 +22,17 @@ $ns.sun.calc = function () {
    * It should be done the same way as the corresponding planetary
    * correction, however.
    */
-  pol [2] = r
-  for (i = 0; i < 2; i++) {
-    t = pol [2] / 173.1446327
+  pol[2] = r
+  for (var i = 0; i < 2; i++) {
+    t = pol[2] / 173.1446327
     /* Find the earth at time TDT - t */
     $moshier.kepler.calc({julian: $moshier.body.earth.position.date.julian - t}, $moshier.body.earth, ecr, pol)
   }
-  r = pol [2]
+  r = pol[2]
 
-  for (i = 0; i < 3; i++) {
-    x = -ecr[i]
-    y = -$moshier.body.earth.position.rect [i] //-rearth[i];
+  for (var i = 0; i < 3; i++) {
+    var x = -ecr[i]
+    var y = -$moshier.body.earth.position.rect[i] // -rearth[i];
     ecr[i] = x
     /* position t days ago */
     rec[i] = y
@@ -54,7 +50,7 @@ $ns.sun.calc = function () {
   /* Estimate rate of change of RA and Dec
    * for use by altaz().
    */
-  d = $util.deltap(ecr, rec)
+  var d = $util.deltap(ecr, rec)
   /* see dms.c */
   $const.dradt = d.dr
   $const.ddecdt = d.dd
@@ -68,7 +64,7 @@ $ns.sun.calc = function () {
   /* precess to equinox of date */
   $moshier.precess.calc(ecr, $moshier.body.earth.position.date, -1)
 
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     rec[i] = ecr[i]
   }
 

--- a/src/astronomy/moshier/transit.js
+++ b/src/astronomy/moshier/transit.js
@@ -28,10 +28,8 @@ $ns.transit = {
 /* Calculate time of transit
  * assuming RA and Dec change uniformly with time
  */
-$ns.transit.calc = function (date, lha, dec, result) {
+$ns.transit.calc = function (date, lha, dec) {
   var NR = [], YR = [];
-
-  result = result || {};
 
   this.f_trnsit = false;
   /* Initialize to no-event flag value. */
@@ -60,12 +58,14 @@ $ns.transit.calc = function (date, lha, dec, result) {
     y -= $const.TPI;
   }
   var lhay = y;
-  y = y/( -$const.dradt/$const.TPI + 1.00273790934);
+  y = y/(-$const.dradt/$const.TPI + 1.00273790934);
   this.r_trnsit = x - y;
   /* printf ("rt %.7f ", r_trnsit); */
   /* Ordinarily never print here. */
-  result.approxLocalMeridian = $util.hms (this.r_trnsit);
-  result.UTdate = this.r_trnsit/$const.TPI;
+  var result = {
+    approxLocalMeridian: $util.hms (this.r_trnsit),
+    UTdate: this.r_trnsit/$const.TPI
+  };
 
   if (coslat != 0.0 && cosdec != 0.0) {
     /* The time at which the upper limb of the body meets the
@@ -154,7 +154,7 @@ $ns.transit.iterator = function (julian, callback) {
 };
 
 /* Iterative computation of rise, transit, and set times. */
-$ns.transit.iterateTransit = function (callback, result) {
+$ns.transit.iterateTransit = function (callback) {
   var date, t0; // double
   var isPrtrnsit = false;
   var loopctr = 0;
@@ -185,7 +185,7 @@ $ns.transit.iterateTransit = function (callback, result) {
       this.t_rise = -1.0;
       this.t_set = -1.0;
       if ($moshier.altaz.elevation > this.elevation_threshold) {
-        this.noRiseSet (this.t_trnsit, callback);
+        this.noRiseSet (callback);
       }
       // goto prtrnsit;
     } else {
@@ -206,7 +206,7 @@ $ns.transit.iterateTransit = function (callback, result) {
           /* Rise or set time not found. Apply search technique. */
           this.t_rise = -1.0;
           this.t_set = -1.0;
-          this.noRiseSet (this.t_trnsit, callback);
+          this.noRiseSet (callback);
           isPrtrnsit = true;
           // goto prtrnsit;
         } else if (++loopctr > 10) {
@@ -244,7 +244,7 @@ $ns.transit.iterateTransit = function (callback, result) {
             /* Rise or set time not found. Apply search technique. */
             this.t_rise = -1.0;
             this.t_set = -1.0;
-            this.noRiseSet (this.t_trnsit, callback);
+            this.noRiseSet (callback);
             isPrtrnsit = true;
             // goto prtrnsit;
           } else if (++loopctr > 10) {
@@ -269,7 +269,7 @@ $ns.transit.iterateTransit = function (callback, result) {
       }
     }
 // prtrnsit:
-    result = result || {};
+    var result = {};
     result.localMeridianTransit = $moshier.julian.toGregorian ({julian: this.t_trnsit});
     if (this.t_rise != -1.0) {
       result.riseDate = $moshier.julian.toGregorian ({julian: this.t_rise});
@@ -302,7 +302,7 @@ $ns.transit.iterateTransit = function (callback, result) {
 /* If the initial approximation fails to locate a rise or set time,
  this function steps between the transit time and the previous
  or next inferior transits to find an event more reliably. */
-$ns.transit.noRiseSet = function (t0, callback) {
+$ns.transit.noRiseSet = function (callback) {
   var t_trnsit0 = this.t_trnsit; // double
   var el_trnsit0 = this.elevation_trnsit; // double
 

--- a/src/astronomy/moshier/transit.js
+++ b/src/astronomy/moshier/transit.js
@@ -29,9 +29,7 @@ $ns.transit = {
  * assuming RA and Dec change uniformly with time
  */
 $ns.transit.calc = function (date, lha, dec, result) {
-  var x, y, N, z, D; // double
-  var lhay, cosdec, sindec, coslat, sinlat; // double
-  var nArr = [], NR = [], NS = [], YR = [], YS = [], zArr = []
+  var NR = [], YR = [];
 
   result = result || {};
 
@@ -40,12 +38,11 @@ $ns.transit.calc = function (date, lha, dec, result) {
   this.r_rise = -10.0;
   this.r_set = -10.0;
   /* observer's geodetic latitude, in radians */
-  x = $const.glat * $const.DTR;
-  coslat = Math.cos(x);
-  sinlat = Math.sin(x);
-
-  cosdec = Math.cos(dec);
-  sindec = Math.sin(dec);
+  var x = $const.glat * $const.DTR;
+  var coslat = Math.cos(x);
+  var sinlat = Math.sin(x);
+  var cosdec = Math.cos(dec);
+  var sindec = Math.sin(dec);
 
   this.southern_hemisphere = sinlat < 0;
 
@@ -54,7 +51,7 @@ $ns.transit.calc = function (date, lha, dec, result) {
   x = Math.floor(date.universal - 0.5) + 0.5; // UT
   x = (date.universal - x) * $const.TPI; // UT
   /* adjust local hour angle */
-  y = lha;
+  var y = lha;
   /* printf ("%.7f,", lha); */
   while (y < -Math.PI) {
     y += $const.TPI;
@@ -62,7 +59,7 @@ $ns.transit.calc = function (date, lha, dec, result) {
   while (y > Math.PI) {
     y -= $const.TPI;
   }
-  lhay = y;
+  var lhay = y;
   y = y/( -$const.dradt/$const.TPI + 1.00273790934);
   this.r_trnsit = x - y;
   /* printf ("rt %.7f ", r_trnsit); */
@@ -77,20 +74,18 @@ $ns.transit.calc = function (date, lha, dec, result) {
     switch ($const.body.key) {
       /* Sun */
       case 'sun':
-        nArr[0] = this.COSSUN;
-        nArr[1] = $const.COSSUN;
         this.semidiameter = 0.2666666666666667;
         this.elevation_threshold = -0.8333333333333333;
-        NR[0] = nArr[0]
-        NR[1] = nArr[1]
+        NR[0] = this.COSSUN
+        NR[1] = $const.COSSUN
         break;
 
       /* Moon, elevation = -34' - semidiameter + parallax
        * semidiameter = 0.272453 * parallax + 0.0799"
        */
       case 'moon':
-        N = 1.0/(this.DISFAC*$const.body.position.polar [2]);
-        D = Math.asin( N ); /* the parallax */
+        var N = 1.0/(this.DISFAC*$const.body.position.polar[2]);
+        var D = Math.asin(N); /* the parallax */
         this.semidiameter = 0.2725076*D + 3.874e-7;
         NR[0] = NR[1] = -9.890199094634534e-3 - this.semidiameter + D;
         this.semidiameter *= $const.RTD;
@@ -100,8 +95,7 @@ $ns.transit.calc = function (date, lha, dec, result) {
 
       /* Other object */
       default:
-        nArr[0] = this.COSZEN;
-        NR[0] = NR[1] = nArr[0]
+        NR[0] = NR[1] = this.COSZEN
         this.semidiameter = 0.0;
         this.elevation_threshold = -0.5666666666666666;
         break;
@@ -117,11 +111,12 @@ $ns.transit.calc = function (date, lha, dec, result) {
       /* Derivative of y with respect to declination
        * times rate of change of declination:
        */
-      z = -$const.ddecdt*(sinlat + this.COSZEN*sindec);
+      var z = -$const.ddecdt*(sinlat + this.COSZEN*sindec);
       z /= $const.TPI*coslat*cosdec*cosdec;
       /* Derivative of acos(y): */
-      zArr[0] = z / Math.sqrt( 1.0 - YR[0]*YR[0]);
-      zArr[1] = z / Math.sqrt( 1.0 - YR[1]*YR[1]);
+      var zArr = [];
+      zArr[0] = z / Math.sqrt(1.0 - YR[0]*YR[0]);
+      zArr[1] = z / Math.sqrt(1.0 - YR[1]*YR[1]);
       YR[0] = Math.acos(YR[0]);
       YR[1] = Math.acos(YR[1]);
       D = -$const.dradt/$const.TPI + 1.00273790934;
@@ -161,16 +156,12 @@ $ns.transit.iterator = function (julian, callback) {
 
 /* Iterative computation of rise, transit, and set times. */
 $ns.transit.iterateTransit = function (callback, result) {
-  var date, date_trnsit, t0, t1; // double
-  var rise1, set1, trnsit1, loopctr, retry; // double
+  var date, t0; // double
   var isPrtrnsit = false;
-
-  result = result || {};
-
-  loopctr = 0;
-  retry = 0;
+  var loopctr = 0;
+  // var retry = 0;
   /* Start iteration at time given by the user. */
-  t1 = $moshier.body.earth.position.date.universal; // UT
+  var t1 = $moshier.body.earth.position.date.universal; // UT
 
   /* Find transit time. */
   do {
@@ -187,8 +178,8 @@ $ns.transit.iterateTransit = function (callback, result) {
   if (loopctr <= 10) {
     this.t_trnsit = t1;
     this.elevation_trnsit = $moshier.altaz.elevation;
-    trnsit1 = this.r_trnsit;
-    set1 = this.r_set;
+    var trnsit1 = this.r_trnsit;
+    var set1 = this.r_set;
     if (!this.f_trnsit) {
       /* Rise or set time not found. Apply a search technique to
        check near inferior transit if object is above horizon now. */
@@ -200,7 +191,7 @@ $ns.transit.iterateTransit = function (callback, result) {
       // goto prtrnsit;
     } else {
       /* Set current date to be that of the transit just found. */
-      date_trnsit = date;
+      var date_trnsit = date;
       t1 = date + this.r_rise / $const.TPI;
       /* Choose rising no later than transit. */
       if (t1 >= this.t_trnsit) {
@@ -234,7 +225,7 @@ $ns.transit.iterateTransit = function (callback, result) {
       } while (Math.abs (t1 - t0) > .0001);
 
       if (!isPrtrnsit) {
-        rise1 = this.r_rise;
+        var rise1 = this.r_rise;
         this.t_rise = t1;
 
         /* Set current date to be that of the transit. */
@@ -279,6 +270,7 @@ $ns.transit.iterateTransit = function (callback, result) {
       }
     }
 // prtrnsit:
+    result = result || {};
     result.localMeridianTransit = $moshier.julian.toGregorian ({julian: this.t_trnsit});
     if (this.t_rise != -1.0) {
       result.riseDate = $moshier.julian.toGregorian ({julian: this.t_rise});
@@ -314,18 +306,16 @@ $ns.transit.iterateTransit = function (callback, result) {
 $ns.transit.noRiseSet = function (t0, callback) {
   var t_trnsit0 = this.t_trnsit; // double
   var el_trnsit0 = this.elevation_trnsit; // double
-  var t, e; // double
-  var t_above, el_above, t_below, el_below; // double
 
   /* Step time toward previous inferior transit to find
    whether a rise event was missed. The step size is a function
    of the azimuth and decreases near the transit time. */
-  t_above = t_trnsit0;
-  el_above = el_trnsit0;
-  t_below = -1.0;
-  el_below = el_above;
-  t = t_trnsit0 - 0.25;
-  e = 1.0;
+  var t_above = t_trnsit0;
+  var el_above = el_trnsit0;
+  var t_below = -1.0;
+  var el_below = el_above;
+  var t = t_trnsit0 - 0.25;
+  var e = 1.0;
   while (e > 0.005) {
     this.iterator (t, callback);
     if ($moshier.altaz.elevation > this.elevation_threshold) {
@@ -421,18 +411,16 @@ $ns.transit.noRiseSet = function (t0, callback) {
 /* Search rise or set time by simple interval halving
  after the event has been bracketed in time. */
 $ns.transit.searchHalve = function (t1, y1, t2, y2, callback) {
-  var e2, e1, em, tm, ym; // double
-
-  e2 = y2 - this.elevation_threshold;
-  e1 = y1 - this.elevation_threshold;
-  tm = 0.5 * (t1 + t2);
+  var e2 = y2 - this.elevation_threshold;
+  // var e1 = y1 - this.elevation_threshold;
+  var tm = 0.5 * (t1 + t2);
 
   while (Math.abs(t2 - t1) > .00001) {
     /* Evaluate at middle of current interval. */
     tm = 0.5 * (t1 + t2);
     this.iterator (tm, callback);
-    ym = $moshier.altaz.elevation;
-    em = ym - this.elevation_threshold;
+    var ym = $moshier.altaz.elevation;
+    var em = ym - this.elevation_threshold;
     /* Replace the interval boundary whose error has the same sign as em. */
     if (em * e2 > 0) {
       y2 = ym;
@@ -441,7 +429,7 @@ $ns.transit.searchHalve = function (t1, y1, t2, y2, callback) {
     } else {
       y1 = ym;
       t1 = tm;
-      e1 = em;
+      // e1 = em;
     }
   }
   return tm;

--- a/src/astronomy/moshier/transit.js
+++ b/src/astronomy/moshier/transit.js
@@ -269,7 +269,7 @@ $ns.transit.iterateTransit = function (callback, result) {
               t1 = date + this.r_set / $const.TPI;
             }
           }
-        } while (fabs(t1 - t0) > .0001);
+        } while (Math.abs(t1 - t0) > .0001);
 
         if (!isPrtrnsit) {
           this.t_set = t1;

--- a/src/astronomy/moshier/transit.js
+++ b/src/astronomy/moshier/transit.js
@@ -84,12 +84,12 @@ $ns.transit.calc = function (date, lha, dec, result) {
        * semidiameter = 0.272453 * parallax + 0.0799"
        */
       case 'moon':
-        var N = 1.0/(this.DISFAC*$const.body.position.polar[2]);
+        var N = 1/(this.DISFAC*$const.body.position.polar[2]);
         var D = Math.asin(N); /* the parallax */
         this.semidiameter = 0.2725076*D + 3.874e-7;
         NR[0] = NR[1] = -9.890199094634534e-3 - this.semidiameter + D;
         this.semidiameter *= $const.RTD;
-        this.elevation_threshold = -34.0/60.0 - this.semidiameter;
+        this.elevation_threshold = -34/60 - this.semidiameter;
         NR[0] = NR[1] = Math.sin(NR[0]);
         break;
 
@@ -104,8 +104,7 @@ $ns.transit.calc = function (date, lha, dec, result) {
     YR[0] = (NR[0] - sinlat*sindec)/(coslat*cosdec);
     YR[1] = (NR[1] - sinlat*sindec)/(coslat*cosdec);
 
-    if (YR[0] < 1.0 && YR[0] > -1.0 && YR[1] < 1.0 && YR[1] > -1.0)
-    {
+    if (YR[0] < 1 && YR[0] > -1 && YR[1] < 1 && YR[1] > -1) {
       this.f_trnsit = true;
 
       /* Derivative of y with respect to declination
@@ -115,15 +114,15 @@ $ns.transit.calc = function (date, lha, dec, result) {
       z /= $const.TPI*coslat*cosdec*cosdec;
       /* Derivative of acos(y): */
       var zArr = [];
-      zArr[0] = z / Math.sqrt(1.0 - YR[0]*YR[0]);
-      zArr[1] = z / Math.sqrt(1.0 - YR[1]*YR[1]);
+      zArr[0] = z / Math.sqrt(1 - YR[0]*YR[0]);
+      zArr[1] = z / Math.sqrt(1 - YR[1]*YR[1]);
       YR[0] = Math.acos(YR[0]);
       YR[1] = Math.acos(YR[1]);
       D = -$const.dradt/$const.TPI + 1.00273790934;
-      this.r_rise = x - (lhay + YR[0])*(1.0 + zArr[0])/D;
-      this.r_set = x - (lhay - YR[0])*(1.0 - zArr[0])/D;
-      this.r_sanatan_rise = x - (lhay + YR[1])*(1.0 + zArr[1])/D;
-      this.r_sanatan_set = x - (lhay - YR[1])*(1.0 - zArr[1])/D;
+      this.r_rise = x - (lhay + YR[0])*(1 + zArr[0])/D;
+      this.r_set = x - (lhay - YR[0])*(1 - zArr[0])/D;
+      this.r_sanatan_rise = x - (lhay + YR[1])*(1 + zArr[1])/D;
+      this.r_sanatan_set = x - (lhay - YR[1])*(1 - zArr[1])/D;
       /* Ordinarily never print here. */
 
       result.dApproxRiseUT = this.r_rise;
@@ -195,7 +194,7 @@ $ns.transit.iterateTransit = function (callback, result) {
       t1 = date + this.r_rise / $const.TPI;
       /* Choose rising no later than transit. */
       if (t1 >= this.t_trnsit) {
-        date -= 1.0;
+        date -= 1;
         t1 = date + this.r_rise / $const.TPI;
       }
       loopctr = 0;
@@ -234,7 +233,7 @@ $ns.transit.iterateTransit = function (callback, result) {
         /* Choose setting no earlier than transit. */
         t1 = date + this.r_set / $const.TPI;
         if (t1 <= this.t_trnsit) {
-          date += 1.0;
+          date += 1;
           t1 = date + this.r_set / $const.TPI;
         }
         loopctr = 0;
@@ -256,7 +255,7 @@ $ns.transit.iterateTransit = function (callback, result) {
           } else {
             t1 = date + this.r_set / $const.TPI;
             if (t1 < this.t_trnsit) {
-              date += 1.0;
+              date += 1;
               t1 = date + this.r_set / $const.TPI;
             }
           }
@@ -279,8 +278,8 @@ $ns.transit.iterateTransit = function (callback, result) {
       result.setDate = $moshier.julian.toGregorian ({julian: this.t_set});
       if (this.t_rise != -1.0) {
         t0 = this.t_set - this.t_rise;
-        if (t0 > 0.0 && t0 < 1.0) {
-          result.visibleHaours = 24.0 * t0;
+        if (t0 > 0 && t0 < 1) {
+          result.visibleHaours = 24 * t0;
         }
       }
     }
@@ -330,15 +329,15 @@ $ns.transit.noRiseSet = function (t0, callback) {
       break; // goto search_rise;
     }
     /* Step time by an amount proportional to the azimuth deviation. */
-    e = azimuth/360.0;
-    if (azimuth < 180.0) {
+    e = azimuth/360;
+    if (azimuth < 180) {
       if (this.southern_hemisphere) {
         t += this.STEP_SCALE * e;
       } else {
         t -= this.STEP_SCALE * e;
       }
     } else {
-      e = 1.0 - e;
+      e = 1 - e;
       if (this.southern_hemisphere) {
         t -= this.STEP_SCALE * e;
       } else {
@@ -379,15 +378,15 @@ $ns.transit.noRiseSet = function (t0, callback) {
       break; // goto search_set;
     }
     /* Step time by an amount proportional to the azimuth deviation. */
-    e = $moshier.altaz.azimuth/360.0;
-    if ($moshier.altaz.azimuth < 180.0) {
+    e = $moshier.altaz.azimuth/360;
+    if ($moshier.altaz.azimuth < 180) {
       if (this.southern_hemisphere) {
         t += this.STEP_SCALE * e; /* Southern hemisphere observer. */
       } else {
         t -= this.STEP_SCALE * e;
       }
     } else {
-      e = 1.0 - e;
+      e = 1 - e;
       if (this.southern_hemisphere) {
         t -= this.STEP_SCALE * e;
       } else {

--- a/src/astronomy/moshier/util.js
+++ b/src/astronomy/moshier/util.js
@@ -1,20 +1,12 @@
 $ns.util = {}
 
 $ns.util.mods3600 = function (value) {
-  var result
-
-  result = (value - 1.296e6 * Math.floor(value / 1.296e6))
-
-  return result
+  return value - 1.296e6 * Math.floor(value / 1.296e6)
 }
 
-/* Reduce x modulo 2 pi
- */
+/* Reduce x modulo 2 pi */
 $ns.util.modtp = function (x) {
-  var y // double
-
-  y = Math.floor(x / $const.TPI)
-  y = x - y * $const.TPI
+  var y = x - Math.floor(x / $const.TPI) * $const.TPI
   while (y < 0.0) {
     y += $const.TPI
   }
@@ -24,14 +16,9 @@ $ns.util.modtp = function (x) {
   return y
 }
 
-/* Reduce x modulo 360 degrees
- */
+/* Reduce x modulo 360 degrees */
 $ns.util.mod360 = function (x) {
-  var k // int
-  var y // double
-
-  k = Math.floor(x / 360.0)
-  y = x - k * 360.0
+  var y = x - Math.floor(x / 360.0) * 360.0
   while (y < 0.0) {
     y += 360.0
   }
@@ -41,14 +28,9 @@ $ns.util.mod360 = function (x) {
   return y
 }
 
-/* Reduce x modulo 30 degrees
- */
+/* Reduce x modulo 30 degrees */
 $ns.util.mod30 = function (x) {
-  var k // int
-  var y // double
-
-  k = Math.floor(x / 30.0)
-  y = x - k * 30.0
+  var y = x - Math.floor(x / 30.0) * 30.0
   while (y < 0.0) {
     y += 30.0
   }
@@ -59,10 +41,7 @@ $ns.util.mod30 = function (x) {
 }
 
 $ns.util.zatan2 = function (x, y) {
-  var z, w // double
-  var code // short
-
-  code = 0
+  var w = 0, code = 0
 
   if (x < 0.0) {
     code = 2
@@ -94,7 +73,7 @@ $ns.util.zatan2 = function (x, y) {
       w = 0.0
       break
     case 1:
-      w = 2.0 * Math.PI
+      w = 2 * Math.PI
       break
     case 2:
     case 3:
@@ -102,9 +81,7 @@ $ns.util.zatan2 = function (x, y) {
       break
   }
 
-  z = Math.atan(y / x)
-
-  return w + z
+  return w + Math.atan(y / x)
 }
 
 $ns.util.sinh = function (x) {
@@ -120,23 +97,18 @@ $ns.util.tanh = function (x) {
 }
 
 $ns.util.hms = function (x) {
-  var h, m // int
-  var sint, sfrac // long
-  var s // double
-  var result = {}
-
-  s = x * $const.RTOH
+  var s = x * $const.RTOH
   if (s < 0.0) {
     s += 24.0
   }
-  h = Math.floor(s)
+  var h = Math.floor(s)
   s -= h
   s *= 60
-  m = Math.floor(s)
+  var m = Math.floor(s)
   s -= m
   s *= 60
   /* Handle shillings and pence roundoff. */
-  sfrac = Math.floor(1000.0 * s + 0.5)
+  var sfrac = Math.floor(1000.0 * s + 0.5)
   if (sfrac >= 60000) {
     sfrac -= 60000
     m += 1
@@ -145,53 +117,47 @@ $ns.util.hms = function (x) {
       h += 1
     }
   }
-  sint = Math.floor(sfrac / 1000)
+  var sint = Math.floor(sfrac / 1000)
   sfrac -= Math.floor(sint * 1000)
 
-  result.hours = h
-  result.minutes = m
-  result.seconds = sint
-  result.milliseconds = sfrac
-
-  return result
+  return {
+    hours: h,
+    minutes: m,
+    seconds: sint,
+    milliseconds: sfrac
+  }
 }
 
 $ns.util.dms = function (x) {
-  var s // double
-  var d, m // int
-  var result = {}
-
-  s = x * $const.RTD
+  var s = x * $const.RTD
   if (s < 0.0) {
     s = -s
   }
-  d = Math.floor(s)
+  var d = Math.floor(s)
   s -= d
   s *= 60
-  m = Math.floor(s)
+  var m = Math.floor(s)
   s -= m
   s *= 60
 
-  result.degree = d
-  result.minutes = m
-  result.seconds = s
-
-  return result
+  return {
+    degree: d,
+    minutes: m,
+    seconds: s
+  }
 }
 
 /* Display magnitude of correction vector
  * in arc seconds
  */
 $ns.util.showcor = function (p, dp, result) {
-  var p1 = [] // dr, dd; // double
-  var i // int
-  var d
+  var p1 = [] // double
 
-  for (i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     p1[i] = p[i] + dp[i]
   }
 
-  d = $util.deltap(p, p1)
+  var d = $util.deltap(p, p1)
 
   result = result || {}
   result.dRA = $const.RTS * d.dr / 15.0
@@ -205,31 +171,23 @@ $ns.util.showcor = function (p, dp, result) {
  * Output vector pol[] contains R.A., Dec., and radius.
  */
 $ns.util.showrd = function (p, pol, result) {
-  var x, y, r // double
-  var i // int
-
-  r = 0.0
-  for (i = 0; i < 3; i++) {
-    x = p[i]
-    r += x * x
+  var r = 0.0
+  for (var i = 0; i < 3; i++) {
+    r += p[i] * p[i]
   }
   r = Math.sqrt(r)
 
-  x = $util.zatan2(p[0], p[1])
-  pol[0] = x
-
-  y = Math.asin(p[2] / r)
-  pol[1] = y
-
+  pol[0] = $util.zatan2(p[0], p[1])
+  pol[1] = Math.asin(p[2] / r)
   pol[2] = r
 
   result = result || {}
 
   $copy(result, {
-    dRA: x,
-    dDec: y,
-    ra: $util.hms(x),
-    dec: $util.dms(y)
+    dRA: pol[0],
+    dDec: pol[1],
+    ra: $util.hms(pol[0]),
+    dec: $util.dms(pol[1])
   })
 
   return result
@@ -244,9 +202,9 @@ $ns.util.showrd = function (p, pol, result) {
  * the change is calculated to first order by differentiating
  *   tan(R.A.) = y/x
  * to obtain
- *    dR.A./cos**2(R.A.) = dy/x  -  y dx/x**2
+ *    dR.A./cos**2(R.A.) = dy/x - y dx/x**2
  * where
- *    cos**2(R.A.)  =  1/(1 + (y/x)**2).
+ *    cos**2(R.A.) = 1/(1 + (y/x)**2)
  *
  * The change in declination arcsin(z/R) is
  *   d asin(u) = du/sqrt(1-u**2)
@@ -257,17 +215,16 @@ $ns.util.showrd = function (p, pol, result) {
  *
  */
 $ns.util.deltap = function (p0, p1, d) {
-  var dp = [], A, B, P, Q, x, y, z // double
-  var i // int
+  var dp = [] // double
 
   d = d || {}
 
-  P = 0.0
-  Q = 0.0
-  z = 0.0
-  for (i = 0; i < 3; i++) {
-    x = p0[i]
-    y = p1[i]
+  var P = 0.0
+  var Q = 0.0
+  var z = 0.0
+  for (var i = 0; i < 3; i++) {
+    var x = p0[i]
+    var y = p1[i]
     P += x * x
     Q += y * y
     y = y - x
@@ -275,10 +232,10 @@ $ns.util.deltap = function (p0, p1, d) {
     z += y * y
   }
 
-  A = Math.sqrt(P)
-  B = Math.sqrt(Q)
+  var A = Math.sqrt(P)
+  var B = Math.sqrt(Q)
 
-  if ((A < 1.e-7) || (B < 1.e-7) || (z / (P + Q)) > 5.e-7) {
+  if (A < 1.e-7 || B < 1.e-7 || z / (P + Q) > 5.e-7) {
     P = $util.zatan2(p0[0], p0[1])
     Q = $util.zatan2(p1[0], p1[1])
     Q = Q - P
@@ -295,8 +252,8 @@ $ns.util.deltap = function (p0, p1, d) {
     return d
   }
 
-  x = p0[0]
-  y = p0[1]
+  var x = p0[0]
+  var y = p0[1]
   if (x == 0.0) {
     d.dr = 1.0e38
   } else {
@@ -317,19 +274,16 @@ $ns.util.deltap = function (p0, p1, d) {
  * The answers are posted in the following global locations:
  */
 $ns.util.angles = function (p, q, e) {
-  var a, b, s // double
-  var i // int
-
   $const.EO = 0.0
   $const.SE = 0.0
   $const.SO = 0.0
   $const.pq = 0.0
   $const.ep = 0.0
   $const.qe = 0.0
-  for (i = 0; i < 3; i++) {
-    a = e[i]
-    b = q[i]
-    s = p[i]
+  for (var i = 0; i < 3; i++) {
+    var a = e[i]
+    var b = q[i]
+    var s = p[i]
     $const.EO += s * s
     $const.SE += a * a
     $const.SO += b * b

--- a/src/astronomy/moshier/util.js
+++ b/src/astronomy/moshier/util.js
@@ -7,7 +7,7 @@ $ns.util.mods3600 = function (value) {
 /* Reduce x modulo 2 pi */
 $ns.util.modtp = function (x) {
   var y = x - Math.floor(x / $const.TPI) * $const.TPI
-  while (y < 0.0) {
+  while (y < 0) {
     y += $const.TPI
   }
   while (y >= $const.TPI) {
@@ -18,24 +18,24 @@ $ns.util.modtp = function (x) {
 
 /* Reduce x modulo 360 degrees */
 $ns.util.mod360 = function (x) {
-  var y = x - Math.floor(x / 360.0) * 360.0
-  while (y < 0.0) {
-    y += 360.0
+  var y = x - Math.floor(x / 360) * 360
+  while (y < 0) {
+    y += 360
   }
-  while (y > 360.0) {
-    y -= 360.0
+  while (y > 360) {
+    y -= 360
   }
   return y
 }
 
 /* Reduce x modulo 30 degrees */
 $ns.util.mod30 = function (x) {
-  var y = x - Math.floor(x / 30.0) * 30.0
-  while (y < 0.0) {
-    y += 30.0
+  var y = x - Math.floor(x / 30) * 30
+  while (y < 0) {
+    y += 30
   }
-  while (y > 30.0) {
-    y -= 30.0
+  while (y > 30) {
+    y -= 30
   }
   return y
 }
@@ -43,34 +43,34 @@ $ns.util.mod30 = function (x) {
 $ns.util.zatan2 = function (x, y) {
   var w = 0, code = 0
 
-  if (x < 0.0) {
+  if (x < 0) {
     code = 2
   }
-  if (y < 0.0) {
+  if (y < 0) {
     code |= 1
   }
 
-  if (x == 0.0) {
+  if (x == 0) {
     if (code & 1) {
       return 1.5 * Math.PI
     }
-    if (y == 0.0) {
-      return 0.0
+    if (y == 0) {
+      return 0
     }
     return 0.5 * Math.PI
   }
 
-  if (y == 0.0) {
+  if (y == 0) {
     if (code & 2) {
       return Math.PI
     }
-    return 0.0
+    return 0
   }
 
   switch (code) {
     default:
     case 0:
-      w = 0.0
+      w = 0
       break
     case 1:
       w = 2 * Math.PI
@@ -98,8 +98,8 @@ $ns.util.tanh = function (x) {
 
 $ns.util.hms = function (x) {
   var s = x * $const.RTOH
-  if (s < 0.0) {
-    s += 24.0
+  if (s < 0) {
+    s += 24
   }
   var h = Math.floor(s)
   s -= h
@@ -108,7 +108,7 @@ $ns.util.hms = function (x) {
   s -= m
   s *= 60
   /* Handle shillings and pence roundoff. */
-  var sfrac = Math.floor(1000.0 * s + 0.5)
+  var sfrac = Math.floor(1000 * s + 0.5)
   if (sfrac >= 60000) {
     sfrac -= 60000
     m += 1
@@ -130,7 +130,7 @@ $ns.util.hms = function (x) {
 
 $ns.util.dms = function (x) {
   var s = x * $const.RTD
-  if (s < 0.0) {
+  if (s < 0) {
     s = -s
   }
   var d = Math.floor(s)
@@ -160,7 +160,7 @@ $ns.util.showcor = function (p, dp, result) {
   var d = $util.deltap(p, p1)
 
   result = result || {}
-  result.dRA = $const.RTS * d.dr / 15.0
+  result.dRA = $const.RTS * d.dr / 15
   result.dDec = $const.RTS * d.dd
 
   return result
@@ -171,7 +171,7 @@ $ns.util.showcor = function (p, dp, result) {
  * Output vector pol[] contains R.A., Dec., and radius.
  */
 $ns.util.showrd = function (p, pol, result) {
-  var r = 0.0
+  var r = 0
   for (var i = 0; i < 3; i++) {
     r += p[i] * p[i]
   }
@@ -240,10 +240,10 @@ $ns.util.deltap = function (p0, p1, d) {
     Q = $util.zatan2(p1[0], p1[1])
     Q = Q - P
     while (Q < -Math.PI) {
-      Q += 2.0 * Math.PI
+      Q += 2 * Math.PI
     }
     while (Q > Math.PI) {
-      Q -= 2.0 * Math.PI
+      Q -= 2 * Math.PI
     }
     d.dr = Q
     P = Math.asin(p0[2] / A)
@@ -258,12 +258,12 @@ $ns.util.deltap = function (p0, p1, d) {
     d.dr = 1.0e38
   } else {
     Q = y / x
-    Q = (dp[1] - dp[0] * y / x) / (x * (1.0 + Q * Q))
+    Q = (dp[1] - dp[0] * y / x) / (x * (1 + Q * Q))
     d.dr = Q
   }
 
   x = p0[2] / A
-  P = Math.sqrt(1.0 - x * x)
+  P = Math.sqrt(1 - x * x)
   d.dd = (p1[2] / B - x) / P
 
   return d
@@ -291,19 +291,19 @@ $ns.util.angles = function (p, q, e) {
     $const.ep += a * s
     $const.qe += b * a
   }
-  $const.EO = Math.sqrt($const.EO)
   /* Distance between Earth and object */
-  $const.SO = Math.sqrt($const.SO)
+  $const.EO = Math.sqrt($const.EO)
   /* Sun - object */
-  $const.SE = Math.sqrt($const.SE)
+  $const.SO = Math.sqrt($const.SO)
   /* Sun - earth */
+  $const.SE = Math.sqrt($const.SE)
   /* Avoid fatality: if object equals sun, SO is zero. */
   if ($const.SO > 1.0e-12) {
-    $const.pq /= $const.EO * $const.SO
     /* cosine of sun-object-earth */
-    $const.qe /= $const.SO * $const.SE
+    $const.pq /= $const.EO * $const.SO
     /* cosine of earth-sun-object */
+    $const.qe /= $const.SO * $const.SE
   }
-  $const.ep /= $const.SE * $const.EO
   /* -cosine of sun-earth-object */
+  $const.ep /= $const.SE * $const.EO
 }

--- a/src/astronomy/moshier/util.js
+++ b/src/astronomy/moshier/util.js
@@ -150,7 +150,7 @@ $ns.util.dms = function (x) {
 /* Display magnitude of correction vector
  * in arc seconds
  */
-$ns.util.showcor = function (p, dp, result) {
+$ns.util.showcor = function (p, dp) {
   var p1 = [] // double
 
   for (var i = 0; i < 3; i++) {
@@ -159,18 +159,17 @@ $ns.util.showcor = function (p, dp, result) {
 
   var d = $util.deltap(p, p1)
 
-  result = result || {}
-  result.dRA = $const.RTS * d.dr / 15
-  result.dDec = $const.RTS * d.dd
-
-  return result
+  return {
+    dRA: $const.RTS * d.dr / 15,
+    dDec: $const.RTS * d.dd
+  }
 }
 
 /* Display Right Ascension and Declination
  * from input equatorial rectangular unit vector.
  * Output vector pol[] contains R.A., Dec., and radius.
  */
-$ns.util.showrd = function (p, pol, result) {
+$ns.util.showrd = function (p, pol) {
   var r = 0
   for (var i = 0; i < 3; i++) {
     r += p[i] * p[i]
@@ -181,7 +180,7 @@ $ns.util.showrd = function (p, pol, result) {
   pol[1] = Math.asin(p[2] / r)
   pol[2] = r
 
-  result = result || {}
+  var result = {}
 
   $copy(result, {
     dRA: pol[0],
@@ -214,10 +213,8 @@ $ns.util.showrd = function (p, pol, result) {
  * p1 is the vector after motion or aberration.
  *
  */
-$ns.util.deltap = function (p0, p1, d) {
-  var dp = [] // double
-
-  d = d || {}
+$ns.util.deltap = function (p0, p1) {
+  var dr, dp = [] // double
 
   var P = 0.0
   var Q = 0.0
@@ -245,28 +242,32 @@ $ns.util.deltap = function (p0, p1, d) {
     while (Q > Math.PI) {
       Q -= 2 * Math.PI
     }
-    d.dr = Q
+    dr = Q
     P = Math.asin(p0[2] / A)
     Q = Math.asin(p1[2] / B)
-    d.dd = Q - P
-    return d
+    return {
+      dd: Q - P,
+      dr: dr
+    }
   }
 
   var x = p0[0]
   var y = p0[1]
   if (x == 0.0) {
-    d.dr = 1.0e38
+    dr = 1.0e38
   } else {
     Q = y / x
     Q = (dp[1] - dp[0] * y / x) / (x * (1 + Q * Q))
-    d.dr = Q
+    dr = Q
   }
 
   x = p0[2] / A
   P = Math.sqrt(1 - x * x)
-  d.dd = (p1[2] / B - x) / P
 
-  return d
+  return {
+    dd: (p1[2] / B - x) / P,
+    dr: dr
+  }
 }
 
 /* Sun - object - earth angles and distances.

--- a/src/astronomy/moshier/vearth.js
+++ b/src/astronomy/moshier/vearth.js
@@ -4,8 +4,7 @@ $ns.vearth = {
 }
 
 $ns.vearth.calc = function (date) {
-  var e = [], p = [], t // double
-  var i // int
+  var e = [], p = [] // double
 
   if (date.julian == this.jvearth) {
     return
@@ -16,10 +15,10 @@ $ns.vearth.calc = function (date) {
   /* calculate heliocentric position of the earth
    * as of a short time ago.
    */
-  t = 0.005
+  var t = 0.005
   $moshier.kepler.calc({julian: date.julian - t}, $moshier.body.earth, e, p)
 
-  for (i = 0; i < 3; i++) {
-    this.vearth [i] = ($moshier.body.earth.position.rect [i] - e[i]) / t
+  for (var i = 0; i < 3; i++) {
+    this.vearth[i] = ($moshier.body.earth.position.rect[i] - e[i]) / t
   }
 }

--- a/src/astronomy/moshier/vearth.js
+++ b/src/astronomy/moshier/vearth.js
@@ -4,7 +4,7 @@ $ns.vearth = {
 }
 
 $ns.vearth.calc = function (date) {
-  var e = [], p = [] // double
+  var e = [] // double
 
   if (date.julian == this.jvearth) {
     return
@@ -16,7 +16,7 @@ $ns.vearth.calc = function (date) {
    * as of a short time ago.
    */
   var t = 0.005
-  $moshier.kepler.calc({julian: date.julian - t}, $moshier.body.earth, e, p)
+  $moshier.kepler.calc({julian: date.julian - t}, $moshier.body.earth, e, [])
 
   for (var i = 0; i < 3; i++) {
     this.vearth[i] = ($moshier.body.earth.position.rect[i] - e[i]) / t


### PR DESCRIPTION
since you were rather receptive to my previous contributions, I offer another one, this one is a little more ugly, haha..

this pull request consists of 3 commits, the first two are self explanatory. For the third one I'll offer some explanation:

_"variable declaration to support type inference"_ - most of the variable declarations within functions were done without initial value, therefore the code failed to leverage JavaScript's wonderful ability to support type inference. Also, many `for` loops were sharing the same `i` variable from a scope broader than necessary. By moving the usage of the `var` keyword to where variables are first used, rather than at the top of the function, we can narrow the scope in many cases (giving each `for` loop it's own `i` variable scoped for it's own use), and we are also able to leverage type inference which is a noticeable improvement to the development experience in most modern JavaScript editors.

The way inference works: JavaScript doesn't support "declarative typing" the way TypeScript does, but it does support "type inference" - If variables are given an initial value at time of declaration, the type can be inferred from the value. This has no functional impact but is noticeable in a JavaScript editor. It is a good first step to providing better typing enforcement while remaining 100% pure JavaScript.

The stronger typing should make it more pleasant for other contributors to engage and should also provide more "type safety" to prevent mistakes as further changes are introduced. Narrowing variable scopes likewise helps prevent mistakes and offers improved readability.

Please take your time to review as there are a lot of changes included.